### PR TITLE
Update YSFHosts.txt

### DIFF
--- a/YSFGateway/YSFHosts.txt
+++ b/YSFGateway/YSFHosts.txt
@@ -33,9 +33,6 @@ ysf262.ysfreflector.de 42000
 # YSF012 / DK YSF012 / C4FM Reflector
 oz2ree.dk 42000
 
-# YSF007 / ES BM-SPAIN / BM 2141
-c4fm.spain-dmr.es 42000
-
 # YSF020 / ES C4FM_CADIZ / SCSF-ED7ZAJ
 ed7zaj.ddns.net 42000
 


### PR DESCRIPTION
 c4fm.spain-dmr.es has been a non resolving host for weeks, removal from list will be the the most effective way to resolve.
Either the host owner fixes the issue, or stays out of the list recommended.