### PR TITLE
Fix compilation in macOS

### DIFF
--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -682,6 +682,12 @@ void CWiresX::sendAllReply()
 		data[offset + 49U] = 0x0DU;
 	}
 
+	unsigned int k = 1029U - offset;
+	for(unsigned int i = 0U; i < k; i++)
+		data[i + offset] = 0x20U;
+	
+	offset += k;
+    
 	data[offset + 0U] = 0x03U;			// End of data marker
 	data[offset + 1U] = CCRC::addCRC(data, offset + 1U);
 

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -45,6 +45,7 @@ const char* DEFAULT_INI_FILE = "/etc/YSFGateway.ini";
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <clocale>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Also added a workaround for the last page of the YSF Reflectors list. The last update didn't show me the last page in my FT1XD.