### PR TITLE
Prints to the log file

### DIFF
--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -772,6 +772,8 @@ void CYSFGateway::startupLinking()
 			}
 		}
 	}
+	if (m_startup.empty())
+		 LogMessage("No connection startup");
 }
 
 void CYSFGateway::readFCSRoomsFile(const std::string& filename)

--- a/YSFGateway/YSFNetwork.cpp
+++ b/YSFGateway/YSFNetwork.cpp
@@ -166,7 +166,11 @@ void CYSFNetwork::clock(unsigned int ms)
 		return;
 
 	if (::memcmp(buffer, "YSFP", 4U) == 0 && !m_linked) {
-		LogMessage("Linked to %s", m_name.c_str());
+		if (strcmp(m_name.c_str(),"MMDVM")== 0)
+			LogMessage("Link successful to %s", m_name.c_str());
+		else
+			LogMessage("Linked to %s", m_name.c_str());
+
 		m_linked = true;
 	}
 


### PR DESCRIPTION
Managed connection status prints to be used with the DG9VH dashboard so that the name of reflector and FCS can be extracted directly from the log. Added printing on the status of no automatic connection.
@dg9vh 