### PR TITLE
Alternate Disconnect

### DIFF
--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -31,6 +31,7 @@
 const unsigned char DX_REQ[]    = {0x5DU, 0x71U, 0x5FU};
 const unsigned char CONN_REQ[]  = {0x5DU, 0x23U, 0x5FU};
 const unsigned char DISC_REQ[]  = {0x5DU, 0x2AU, 0x5FU};
+const unsigned char DISC_REQ2[] = {0x5DU, 0x63U, 0x5FU};
 const unsigned char ALL_REQ[]   = {0x5DU, 0x66U, 0x5FU};
 const unsigned char CAT_REQ[]   = {0x5DU, 0x67U, 0x5FU};
 
@@ -238,6 +239,9 @@ WX_STATUS CWiresX::process(const unsigned char* data, const unsigned char* sourc
                         } else if (::memcmp(m_command + 1U, DISC_REQ, 3U) == 0) {
                                 processDisconnect(source);
                                 return WXS_DISCONNECT;
+			} else if (::memcmp(m_command + 1U, DISC_REQ2, 3U) == 0) {
+                                processDisconnect(source);
+                                return WXS_DISCONNECT;
                         } else if (::memcmp(m_command + 1U, CAT_REQ, 3U) == 0) {
                                 return WXS_NONE;
                         } else {
@@ -256,6 +260,9 @@ WX_STATUS CWiresX::process(const unsigned char* data, const unsigned char* sourc
                         } else if (::memcmp(m_command + 1U, CONN_REQ, 3U) == 0) {
                                 return processConnect(source, m_command + 5U);
                         } else if (::memcmp(m_command + 1U, DISC_REQ, 3U) == 0) {
+                                processDisconnect(source);
+                                return WXS_DISCONNECT;
+			} else if (::memcmp(m_command + 1U, DISC_REQ2, 3U) == 0) {
                                 processDisconnect(source);
                                 return WXS_DISCONNECT;
                         } else if (::memcmp(m_command + 1U, CAT_REQ, 3U) == 0) {


### PR DESCRIPTION
Clicking the connected reflector on the Yaesu FT2D screen issues a command that WiresX.cpp could not cope with;

M: 2019-01-29 20:27:58.615 0000:  2B 5D 63 5F 28 30 30 30 30 34 38 36 32 32 36 03    *+]c_(0000486226.*
M: 2019-01-29 20:27:58.615 0010:  71 00 00 00

After a little trial and error, the radio appears to expect that to disconnect the connected reflector.
This PR adds in this functionality.