### PR TITLE
Tag XLX reflectors as Wires-X capable, allowing passthrough

### DIFF
--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -139,7 +139,11 @@ bool CYSFReflectors::load()
 					refl->m_port    = (unsigned int)::atoi(p5);
 					refl->m_count   = std::string(p6);
 					refl->m_type    = YT_YSF;
-					refl->m_wiresX  = false;
+
+					if (refl->m_name.compare(0, 3, "XLX") == 0)
+						refl->m_wiresX = true;
+					else
+						refl->m_wiresX = false;
 
 					refl->m_name.resize(16U, ' ');
 					refl->m_desc.resize(14U, ' ');

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -139,11 +139,7 @@ bool CYSFReflectors::load()
 					refl->m_port    = (unsigned int)::atoi(p5);
 					refl->m_count   = std::string(p6);
 					refl->m_type    = YT_YSF;
-
-					if (refl->m_name.compare(0, 3, "XLX") == 0)
-						refl->m_wiresX = true;
-					else
-						refl->m_wiresX = false;
+					refl->m_wiresX  = (refl->m_name.compare(0, 3, "XLX") == 0);
 
 					refl->m_name.resize(16U, ' ');
 					refl->m_desc.resize(14U, ' ');


### PR DESCRIPTION
This is a very small patch to enable Wires-X passthrough for XLX reflectors, i.e. reflectors on YSFHosts.txt which name starts by "XLX".

I did some tests and I can tell this works very well but with one caveat, on my FT-1D after I connect to a XLX reflector then I need to disable and re-enable Wires-X mode on the radio else it ignores any Wires-X replies from the XLX (despite commands take effect). Similar procedure is also required after disconnecting from the XLX and getting back to YSFGateway. I guess this happens because XLX reports a repeater ID different of the YSFGateway one. I think it will not be easy to make these match without considerable changes, eventually at both sides... however even with this caveat I think the passthrough feature is very useful for the new YSF-ready XLX reflectors. Also from my tests I can tell that this problem doesn't happen on FT-991A, I could only see it on FT-1D, not sure about other radios?