### PR TITLE
Add Option to Bind to Address

### DIFF
--- a/YSFReflector/Conf.cpp
+++ b/YSFReflector/Conf.cpp
@@ -45,7 +45,8 @@ m_logFileLevel(0U),
 m_logFilePath(),
 m_logFileRoot(),
 m_networkPort(0U),
-m_networkDebug(false)
+m_networkDebug(false),
+m_networkBindAddr()
 {
 }
 
@@ -112,6 +113,8 @@ bool CConf::read()
 			  m_networkPort = (unsigned int)::atoi(value);
 		  else if (::strcmp(key, "Debug") == 0)
 			  m_networkDebug = ::atoi(value) == 1;
+		  else if (::strcmp(key, "BindAddress") == 0)
+			  m_networkBindAddr = value;
 	  }
   }
 
@@ -168,4 +171,9 @@ unsigned int CConf::getNetworkPort() const
 bool CConf::getNetworkDebug() const
 {
 	return m_networkDebug;
+}
+
+std::string CConf::getNetworkBindAddr() const
+{
+	return m_networkBindAddr;
 }

--- a/YSFReflector/Conf.h
+++ b/YSFReflector/Conf.h
@@ -47,6 +47,7 @@ public:
   // The Network section
   unsigned int getNetworkPort() const;
   bool         getNetworkDebug() const;
+  std::string  getNetworkBindAddr() const;
 
 private:
   std::string  m_file;
@@ -63,6 +64,7 @@ private:
 
   unsigned int m_networkPort;
   bool         m_networkDebug;
+  std::string  m_networkBindAddr;
 };
 
 #endif

--- a/YSFReflector/Network.cpp
+++ b/YSFReflector/Network.cpp
@@ -44,11 +44,14 @@ CNetwork::~CNetwork()
 	delete[] m_status;
 }
 
-bool CNetwork::open()
+bool CNetwork::open(const char* bindaddr)
 {
-	::fprintf(stdout, "Opening YSF network connection\n");
+	if (strlen(bindaddr) > 0)
+		::fprintf(stdout, "Opening YSF network connection on address %s\n", bindaddr);
+	else 
+		::fprintf(stdout, "Opening YSF network connection on all interfaces\n");
 
-	return m_socket.open();
+	return m_socket.open(bindaddr);
 }
 
 bool CNetwork::writeData(const unsigned char* data, const in_addr& address, unsigned int port)

--- a/YSFReflector/Network.cpp
+++ b/YSFReflector/Network.cpp
@@ -44,10 +44,10 @@ CNetwork::~CNetwork()
 	delete[] m_status;
 }
 
-bool CNetwork::open(const char* bindaddr)
+bool CNetwork::open(const std::string& bindaddr)
 {
-	if (strlen(bindaddr) > 0)
-		::fprintf(stdout, "Opening YSF network connection on address %s\n", bindaddr);
+	if (bindaddr.length() > 0)
+		::fprintf(stdout, "Opening YSF network connection on address %s\n", bindaddr.c_str());
 	else 
 		::fprintf(stdout, "Opening YSF network connection on all interfaces\n");
 

--- a/YSFReflector/Network.h
+++ b/YSFReflector/Network.h
@@ -31,7 +31,7 @@ public:
 	CNetwork(unsigned int port, unsigned int id, const std::string& name, const std::string& description, bool debug);
 	~CNetwork();
 
-	bool open(const char* bindaddr);
+	bool open(const std::string& bindaddr);
 
 	bool writeData(const unsigned char* data, const in_addr& address, unsigned int port);
 	bool writePoll(const in_addr& address, unsigned int port);

--- a/YSFReflector/Network.h
+++ b/YSFReflector/Network.h
@@ -31,7 +31,7 @@ public:
 	CNetwork(unsigned int port, unsigned int id, const std::string& name, const std::string& description, bool debug);
 	~CNetwork();
 
-	bool open();
+	bool open(const char* bindaddr);
 
 	bool writeData(const unsigned char* data, const in_addr& address, unsigned int port);
 	bool writePoll(const in_addr& address, unsigned int port);

--- a/YSFReflector/UDPSocket.cpp
+++ b/YSFReflector/UDPSocket.cpp
@@ -102,7 +102,7 @@ in_addr CUDPSocket::lookup(const std::string& hostname)
 #endif
 }
 
-bool CUDPSocket::open()
+bool CUDPSocket::open(const char* bindaddr)
 {
 	m_fd = ::socket(PF_INET, SOCK_DGRAM, 0);
 	if (m_fd < 0) {
@@ -119,7 +119,16 @@ bool CUDPSocket::open()
 		::memset(&addr, 0x00, sizeof(sockaddr_in));
 		addr.sin_family      = AF_INET;
 		addr.sin_port        = htons(m_port);
-		addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+		if ( strlen(bindaddr) > 0){
+			int validaddr = inet_pton(AF_INET, bindaddr, &(addr.sin_addr));
+			if (validaddr != 1){
+				LogError("The BindAddress in the .ini is invalid - %s", bindaddr);
+				return false;
+			}
+		} else {
+			addr.sin_addr.s_addr = htonl(INADDR_ANY);
+		}
 
 		if (!m_address.empty()) {
 #if defined(_WIN32) || defined(_WIN64)

--- a/YSFReflector/UDPSocket.cpp
+++ b/YSFReflector/UDPSocket.cpp
@@ -102,7 +102,7 @@ in_addr CUDPSocket::lookup(const std::string& hostname)
 #endif
 }
 
-bool CUDPSocket::open(const char* bindaddr)
+bool CUDPSocket::open(const std::string& bindaddr)
 {
 	m_fd = ::socket(PF_INET, SOCK_DGRAM, 0);
 	if (m_fd < 0) {
@@ -120,10 +120,10 @@ bool CUDPSocket::open(const char* bindaddr)
 		addr.sin_family      = AF_INET;
 		addr.sin_port        = htons(m_port);
 
-		if ( strlen(bindaddr) > 0){
-			int validaddr = inet_pton(AF_INET, bindaddr, &(addr.sin_addr));
+		if ( bindaddr.length() > 0){
+			int validaddr = inet_pton(AF_INET, bindaddr.c_str(), &(addr.sin_addr));
 			if (validaddr != 1){
-				LogError("The BindAddress in the .ini is invalid - %s", bindaddr);
+				LogError("The BindAddress in the .ini is invalid - %s", bindaddr.c_str());
 				return false;
 			}
 		} else {

--- a/YSFReflector/UDPSocket.h
+++ b/YSFReflector/UDPSocket.h
@@ -40,7 +40,7 @@ public:
 	CUDPSocket(unsigned int port = 0U);
 	~CUDPSocket();
 
-	bool open();
+	bool open(const char* bindaddr);
 
 	int  read(unsigned char* buffer, unsigned int length, in_addr& address, unsigned int& port);
 	bool write(const unsigned char* buffer, unsigned int length, const in_addr& address, unsigned int port);

--- a/YSFReflector/UDPSocket.h
+++ b/YSFReflector/UDPSocket.h
@@ -40,7 +40,7 @@ public:
 	CUDPSocket(unsigned int port = 0U);
 	~CUDPSocket();
 
-	bool open(const char* bindaddr);
+	bool open(const std::string& bindaddr);
 
 	int  read(unsigned char* buffer, unsigned int length, in_addr& address, unsigned int& port);
 	bool write(const unsigned char* buffer, unsigned int length, const in_addr& address, unsigned int port);

--- a/YSFReflector/YSFReflector.cpp
+++ b/YSFReflector/YSFReflector.cpp
@@ -164,9 +164,7 @@ void CYSFReflector::run()
 
 	CNetwork network(m_conf.getNetworkPort(), m_conf.getId(), m_conf.getName(), m_conf.getDescription(), m_conf.getNetworkDebug());
 
-	const char* bindaddr = m_conf.getNetworkBindAddr().c_str();
-
-	ret = network.open(bindaddr);
+	ret = network.open(m_conf.getNetworkBindAddr().c_str());
 	if (!ret) {
 		::LogFinalise();
 		return;

--- a/YSFReflector/YSFReflector.cpp
+++ b/YSFReflector/YSFReflector.cpp
@@ -164,7 +164,9 @@ void CYSFReflector::run()
 
 	CNetwork network(m_conf.getNetworkPort(), m_conf.getId(), m_conf.getName(), m_conf.getDescription(), m_conf.getNetworkDebug());
 
-	ret = network.open();
+	const char* bindaddr = m_conf.getNetworkBindAddr().c_str();
+
+	ret = network.open(bindaddr);
 	if (!ret) {
 		::LogFinalise();
 		return;

--- a/YSFReflector/YSFReflector.cpp
+++ b/YSFReflector/YSFReflector.cpp
@@ -164,7 +164,7 @@ void CYSFReflector::run()
 
 	CNetwork network(m_conf.getNetworkPort(), m_conf.getId(), m_conf.getName(), m_conf.getDescription(), m_conf.getNetworkDebug());
 
-	ret = network.open(m_conf.getNetworkBindAddr().c_str());
+	ret = network.open(m_conf.getNetworkBindAddr());
 	if (!ret) {
 		::LogFinalise();
 		return;

--- a/YSFReflector/YSFReflector.ini
+++ b/YSFReflector/YSFReflector.ini
@@ -18,3 +18,6 @@ FileRoot=YSFReflector
 [Network]
 Port=42000
 Debug=0
+# By default, listen on all IPs. To bind to 
+# a specific IP uncomment and set a local address
+#BindAddress=192.0.2.1


### PR DESCRIPTION
This patchset adds a BindAddress configuration option to allow binding of YSFReflector to one particular IP on a host.