### PR TITLE
Update processWiresX return type definition in class

### DIFF
--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -67,7 +67,7 @@ private:
 
 	void startupLinking();
 	std::string calculateLocator();
-	void processWiresX(const unsigned char* buffer, unsigned char fi, unsigned char dt, unsigned char fn, unsigned char ft, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough);
+	bool processWiresX(const unsigned char* buffer, unsigned char fi, unsigned char dt, unsigned char fn, unsigned char ft, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough);
 	void processDTMF(unsigned char* buffer, unsigned char dt);
 	void createWiresX(CYSFNetwork* rptNetwork);
 	void createGPS();


### PR DESCRIPTION
Changed processWiresX return type in file YSFGateway.cpp, I must to change definition in class.