### PR TITLE
YSF2PCM support

### DIFF
--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -50,6 +50,7 @@ m_myAddress(),
 m_myPort(0U),
 m_wiresXMakeUpper(true),
 m_wiresXCommandPassthrough(false),
+m_wiresXCommandBypass(false),
 m_debug(false),
 m_daemon(false),
 m_rxFrequency(0U),
@@ -85,6 +86,8 @@ m_ysfNetworkYSF2NXDNAddress("127.0.0.1"),
 m_ysfNetworkYSF2NXDNPort(0U),
 m_ysfNetworkYSF2P25Address("127.0.0.1"),
 m_ysfNetworkYSF2P25Port(0U),
+m_ysfNetworkYSF2PCMAddress("127.0.0.1"),
+m_ysfNetworkYSF2PCMPort(0U),
 m_fcsNetworkEnabled(false),
 m_fcsNetworkFile(),
 m_fcsNetworkPort(0U),
@@ -170,6 +173,8 @@ bool CConf::read()
 			m_wiresXMakeUpper = ::atoi(value) == 1;
 		else if (::strcmp(key, "WiresXCommandPassthrough") == 0)
 			m_wiresXCommandPassthrough = ::atoi(value) == 1;
+		else if (::strcmp(key, "WiresXCommandBypass") == 0)
+			m_wiresXCommandBypass = ::atoi(value) == 1;
 		else if (::strcmp(key, "Debug") == 0)
 			m_debug = ::atoi(value) == 1;
 		else if (::strcmp(key, "Daemon") == 0)
@@ -245,6 +250,10 @@ bool CConf::read()
 			m_ysfNetworkYSF2P25Address = value;
 		else if (::strcmp(key, "YSF2P25Port") == 0)
 			m_ysfNetworkYSF2P25Port = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "YSF2PCMAddress") == 0)
+			m_ysfNetworkYSF2PCMAddress = value;
+		else if (::strcmp(key, "YSF2PCMPort") == 0)
+			m_ysfNetworkYSF2PCMPort = (unsigned int)::atoi(value);
 	} else if (section == SECTION_FCS_NETWORK) {
 		if (::strcmp(key, "Enable") == 0)
 			m_fcsNetworkEnabled = ::atoi(value) == 1;
@@ -315,6 +324,11 @@ bool CConf::getWiresXMakeUpper() const
 bool CConf::getWiresXCommandPassthrough() const
 {
 	return m_wiresXCommandPassthrough;
+}
+
+bool CConf::getWiresXCommandBypass() const
+{
+	return m_wiresXCommandBypass;
 }
 
 bool CConf::getDebug() const
@@ -490,6 +504,16 @@ std::string CConf::getYSFNetworkYSF2P25Address() const
 unsigned int CConf::getYSFNetworkYSF2P25Port() const
 {
 	return m_ysfNetworkYSF2P25Port;
+}
+
+std::string CConf::getYSFNetworkYSF2PCMAddress() const
+{
+	return m_ysfNetworkYSF2PCMAddress;
+}
+
+unsigned int CConf::getYSFNetworkYSF2PCMPort() const
+{
+	return m_ysfNetworkYSF2PCMPort;
 }
 
 

--- a/YSFGateway/Conf.h
+++ b/YSFGateway/Conf.h
@@ -39,6 +39,7 @@ public:
   unsigned int getMyPort() const;
   bool         getWiresXMakeUpper() const;
   bool         getWiresXCommandPassthrough() const;
+  bool         getWiresXCommandBypass() const;
   bool         getDebug() const;
   bool         getDaemon() const;
 
@@ -84,6 +85,8 @@ public:
   unsigned int getYSFNetworkYSF2NXDNPort() const;
   std::string  getYSFNetworkYSF2P25Address() const;
   unsigned int getYSFNetworkYSF2P25Port() const;
+  std::string  getYSFNetworkYSF2PCMAddress() const;
+  unsigned int getYSFNetworkYSF2PCMPort() const;
 
   // The FCS Network section
   bool         getFCSNetworkEnabled() const;
@@ -110,6 +113,7 @@ private:
   unsigned int m_myPort;
   bool         m_wiresXMakeUpper;
   bool         m_wiresXCommandPassthrough;
+  bool         m_wiresXCommandBypass;
   bool         m_debug;
   bool         m_daemon;
 
@@ -150,6 +154,8 @@ private:
   unsigned int m_ysfNetworkYSF2NXDNPort;
   std::string  m_ysfNetworkYSF2P25Address;
   unsigned int m_ysfNetworkYSF2P25Port;
+  std::string  m_ysfNetworkYSF2PCMAddress;
+  unsigned int m_ysfNetworkYSF2PCMPort;
 
   bool         m_fcsNetworkEnabled;
   std::string  m_fcsNetworkFile;

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -173,6 +173,11 @@ void CWiresX::setYSF2P25(const std::string& address, unsigned int port)
 	m_reflectors.setYSF2P25(address, port);
 }
 
+void CWiresX::setYSF2PCM(const std::string& address, unsigned int port)
+{
+	m_reflectors.setYSF2PCM(address, port);
+}
+
 void CWiresX::addFCSRoom(const std::string& id, const std::string& name)
 {
 	m_reflectors.addFCSRoom(id, name);

--- a/YSFGateway/WiresX.h
+++ b/YSFGateway/WiresX.h
@@ -54,6 +54,7 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned int port);
 	void setYSF2NXDN(const std::string& address, unsigned int port);
 	void setYSF2P25(const std::string& address, unsigned int port);
+	void setYSF2PCM(const std::string& address, unsigned int port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool start();

--- a/YSFGateway/YSFGateway.ini
+++ b/YSFGateway/YSFGateway.ini
@@ -11,7 +11,7 @@ WiresXMakeUpper=1
 WiresXCommandPassthrough=0
 WiresXCommandBypass=0
 Debug=0
-Daemon=0
+Daemon=1
 
 [Info]
 RXFrequency=430475000

--- a/YSFGateway/YSFGateway.ini
+++ b/YSFGateway/YSFGateway.ini
@@ -9,6 +9,7 @@ LocalAddress=127.0.0.1
 LocalPort=4200
 WiresXMakeUpper=1
 WiresXCommandPassthrough=0
+WiresXCommandBypass=0
 Debug=0
 Daemon=0
 
@@ -56,6 +57,8 @@ YSF2NXDNAddress=127.0.0.1
 YSF2NXDNPort=42014
 YSF2P25Address=127.0.0.1
 YSF2P25Port=42015
+YSF2PCMAddress=127.0.0.1
+YSF2PCMPort=42016
 
 [FCS Network]
 Enable=1

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -36,6 +36,8 @@ m_YSF2NXDNAddress(),
 m_YSF2NXDNPort(0U),
 m_YSF2P25Address(),
 m_YSF2P25Port(0U),
+m_YSF2PCMAddress(),
+m_YSF2PCMPort(0U),
 m_fcsRooms(),
 m_newReflectors(),
 m_currReflectors(),
@@ -98,6 +100,12 @@ void CYSFReflectors::setYSF2P25(const std::string& address, unsigned int port)
 {
 	m_YSF2P25Address = address;
 	m_YSF2P25Port    = port;
+}
+
+void CYSFReflectors::setYSF2PCM(const std::string& address, unsigned int port)
+{
+	m_YSF2PCMAddress = address;
+	m_YSF2PCMPort    = port;
 }
 
 void CYSFReflectors::addFCSRoom(const std::string& id, const std::string& name)
@@ -221,6 +229,23 @@ bool CYSFReflectors::load()
 		m_newReflectors.push_back(refl);
 
 		LogInfo("Loaded YSF2P25");
+	}
+	
+	// Add the YSF2PCM entry
+	if (m_YSF2PCMPort > 0U) {
+		CYSFReflector* refl = new CYSFReflector;
+		refl->m_id      = "00005";
+		refl->m_name    = "YSF2PCM         ";
+		refl->m_desc    = "Link YSF2PCM  ";
+		refl->m_address = CUDPSocket::lookup(m_YSF2PCMAddress);
+		refl->m_port    = m_YSF2PCMPort;
+		refl->m_count   = "000";
+		refl->m_type    = YT_YSF;
+		refl->m_wiresX  = true;
+
+		m_newReflectors.push_back(refl);
+
+		LogInfo("Loaded YSF2PCM");
 	}
 
 	unsigned int id = 10U;

--- a/YSFGateway/YSFReflectors.h
+++ b/YSFGateway/YSFReflectors.h
@@ -63,6 +63,7 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned int port);
 	void setYSF2NXDN(const std::string& address, unsigned int port);
 	void setYSF2P25(const std::string& address, unsigned int port);
+	void setYSF2PCM(const std::string& address, unsigned int port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool load();
@@ -88,6 +89,8 @@ private:
 	unsigned int                m_YSF2NXDNPort;
 	std::string                 m_YSF2P25Address;
 	unsigned int                m_YSF2P25Port;
+	std::string                 m_YSF2PCMAddress;
+	unsigned int                m_YSF2PCMPort;
 	std::vector<std::pair<std::string, std::string>> m_fcsRooms;
 	std::vector<CYSFReflector*> m_newReflectors;
 	std::vector<CYSFReflector*> m_currReflectors;

--- a/YSFReflector/YSFReflector.ini
+++ b/YSFReflector/YSFReflector.ini
@@ -1,5 +1,5 @@
 [General]
-Daemon=0
+Daemon=1
 
 [Info]
 # Remember to register your YSFReflector at:

--- a/YSFReflector/YSFReflector.ini
+++ b/YSFReflector/YSFReflector.ini
@@ -1,5 +1,5 @@
 [General]
-Daemon=1
+Daemon=0
 
 [Info]
 # Remember to register your YSFReflector at:
@@ -17,7 +17,7 @@ FileRoot=YSFReflector
 
 [Network]
 Port=42000
-Debug=0
+Debug=1
 # By default, listen on all IPs. To bind to 
 # a specific IP uncomment and set a local address
 #BindAddress=192.0.2.1


### PR DESCRIPTION
This adds support for YSF2PCM, part of MMDVM_PCM, a set of utilities to use an analog radio with PiStar as a digital transceiver.  The details are here:
http://www.dudetronics.com/index.php/dude-star-radio-project
