### PR TITLE
Re-open UDP socket on ENOTSOCK error (FCSNetwork:42001)

### DIFF
--- a/YSFGateway/UDPSocket.cpp
+++ b/YSFGateway/UDPSocket.cpp
@@ -207,12 +207,13 @@ int CUDPSocket::read(unsigned char* buffer, unsigned int length, in_addr& addres
 		LogError("Error returned from recvfrom, err: %lu", ::GetLastError());
 #else
 		LogError("Error returned from recvfrom, err: %d", errno);
-#endif
+
 		if ((len == -1) && (errno == ENOTSOCK)) {
 			LogInfo("Re-opening UDP port on %u", m_port);
 			close();
 			open();
 		}
+#endif
 
 		return -1;
 	}

--- a/YSFGateway/UDPSocket.cpp
+++ b/YSFGateway/UDPSocket.cpp
@@ -208,6 +208,12 @@ int CUDPSocket::read(unsigned char* buffer, unsigned int length, in_addr& addres
 #else
 		LogError("Error returned from recvfrom, err: %d", errno);
 #endif
+		if ((len == -1) && (errno == ENOTSOCK)) {
+			LogInfo("Re-opening UDP port on %u", m_port);
+			close();
+			open();
+		}
+
 		return -1;
 	}
 


### PR DESCRIPTION
Once every night, on all my hotspots running YSFGateway, between 00h and 01h, the FCS connection looks to being dropped, then YSFGateway start to log like crazy error messages "Error returned from recvfrom, err: 88" until the disk space get full.
So, adding a close()/open() cycle in such case fixes the problem, and let the system in a running state, just logging one error message + one info:
E: 2020-10-15 00:50:26.118 Error returned from recvfrom, err: 88
I: 2020-10-15 00:50:26.118 Re-opening UDP port on 42001