### PR TITLE
Add FT-5R to the list of supported radios + icon

### DIFF
--- a/YSFGateway/APRSWriter.cpp
+++ b/YSFGateway/APRSWriter.cpp
@@ -158,12 +158,15 @@ void CAPRSWriter::write(const unsigned char* source, const char* type, unsigned 
 	case 0x24U:
 	case 0x28U:
 	case 0x30U:
+	case 0x33U:
 		symbol = '[';
 		break;
 	case 0x25U:
 	case 0x29U:
+	case 0x31U:
 		symbol = '>';
 		break;
+	case 0x20U:
 	case 0x26U:
 		symbol = 'r';
 		break;

--- a/YSFGateway/GPS.cpp
+++ b/YSFGateway/GPS.cpp
@@ -270,6 +270,9 @@ void CGPS::transmitGPS(const unsigned char* source)
 	case 0x30U:
 		::strcpy(radio, "FT-3D");
 		break;
+	case 0x33U:
+		::strcpy(radio, "FT-5D");
+		break;
 	default:
 		::sprintf(radio, "0x%02X", m_buffer[4U]);
 		break;


### PR DESCRIPTION
Add non-default APRS icon for the FTM-300D and DR-2X.