### PR TITLE
fix wiresx cmd passthrough happening even disabled

### DIFF
--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -281,10 +281,12 @@ int CYSFGateway::run()
 				CYSFReflector* reflector = m_wiresX->getReflector();
 				if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wiresXCommandPassthrough && reflector->m_wiresX) {
 					processDTMF(buffer, dt);
-					m_exclude = processWiresX(buffer, fich, true, wiresXCommandPassthrough);
+					processWiresX(buffer, fich, true, wiresXCommandPassthrough);
 				} else {
+					if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && reflector->m_wiresX)
+						m_exclude = (dt == YSF_DT_DATA_FR_MODE);
 					processDTMF(buffer, dt);
-					m_exclude = processWiresX(buffer, fich, false, wiresXCommandPassthrough);
+					processWiresX(buffer, fich, false, wiresXCommandPassthrough);
 				}
 
 				if (m_gps != NULL)
@@ -530,10 +532,8 @@ void CYSFGateway::createWiresX(CYSFNetwork* rptNetwork)
 	m_wiresX->start();
 }
 
-bool CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fich, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough)
+void CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fich, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough)
 {
-	bool ret=true;
-	
 	assert(buffer != NULL);
 
 	WX_STATUS status = m_wiresX->process(buffer + 35U, buffer + 14U, fich, dontProcessWiresXLocal);
@@ -624,10 +624,8 @@ bool CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fic
 		}
 		break;
 	default:
-		ret = false;
 		break;
 	}
-	return ret;
 }
 
 void CYSFGateway::processDTMF(unsigned char* buffer, unsigned char dt)

--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -69,7 +69,7 @@ private:
 
 	void startupLinking();
 	std::string calculateLocator();
-	bool processWiresX(const unsigned char* buffer, const CYSFFICH& fich, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough);
+	void processWiresX(const unsigned char* buffer, const CYSFFICH& fich, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough);
 	void processDTMF(unsigned char* buffer, unsigned char dt);
 	void createWiresX(CYSFNetwork* rptNetwork);
 	void createGPS();


### PR DESCRIPTION
PR https://github.com/g4klx/YSFClients/pull/185 (to allow sending text messages/pictures) introduced a problem that causes wiresx commands to be also passed through (fully or partially) to reflectors unintentionally even with WiresXCommandPassthrough=0, this is a major problem for eg. when linked to a XLX reflector (with WiresXCommandPassthrough=0) as if we issue wiresx commands they are actually being replied by both local YSFGateway and remote XLX, and radio doesn't seem to recognize any reply at all, waits until timeout...

Actually there are two issues with the implementation on https://github.com/g4klx/YSFClients/pull/185, one is that the check of WX_STATUS var introduced on processWiresX() doesn't take in account that WXS_NONE is returned when processing DX, ALL and CAT thus doesn't even try to filter these (this would be easy to fix obviously), but there is a second problem, from what I could understand actually each wiresx command is composed by multiple packets and processWiresX() is called multiple times until command is complete/validated, then the implementation fails by allowing to partially pass the first packets of the command, as m_exclude is only really set once, when the command is validated, but some packets already passed through, from what I could see for example on a command composed by 5 packets only the 4rd one was actually filtered, and XLX was able to still fully recognize the wiresx command with the 4 non-filtered packets and replied it as described above. I think this is a flawed implementation and I guess to do a proper filtering (dropping all packets) of wiresx commands may not be so easy?

Unless there is a better way to do it, I'm submitting this patch that reverts the changes on #185 and applies a small change to still allow sending text messages/pictures without problems (I hope), with my change:
-> if **WiresXCommandPassthrough is enabled** and we are linked on **wiresx capable reflector**: all data is passed through to reflector (this is unchanged and always happened with or without #185 )
-> if **WiresXCommandPassthrough is disabled** and we are linked on **wiresx capable reflector** (XLX or YSF2xxx): filter all data (as done originally before #185 ), these reflectors do not support messages/pictures anyway then no problem.
-> if **WiresXCommandPassthrough is disabled/enabled** and we are linked on **NON wiresx capable reflector**: allow all data to be passed transparently to reflector, this will allow messages/pictures on these reflectors, wiresx commands will also be passed but these reflectors doesn't process/reply them anyway, think not a problem...
