### PR TITLE
Version string (git id) consistency with other clients/gateways

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ DGIdGateway/DGIdGateway
 YSFGateway/YSFGateway
 YSFParrot/YSFParrot
 YSFReflector/YSFReflector
+GitVersion.h

--- a/DGIdGateway/DGIdGateway.cpp
+++ b/DGIdGateway/DGIdGateway.cpp
@@ -30,6 +30,7 @@
 #include "Timer.h"
 #include "Utils.h"
 #include "Log.h"
+#include "GitVersion.h"
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
@@ -69,7 +70,7 @@ int main(int argc, char** argv)
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {
-				::fprintf(stdout, "DGIdGateway version %s\n", VERSION);
+				::fprintf(stdout, "DGIdGateway version %s git #%.7s\n", VERSION, gitversion);
 				return 0;
 			} else if (arg.substr(0, 1) == "-") {
 				::fprintf(stderr, "Usage: DGIdGateway [-v|--version] [filename]\n");
@@ -407,7 +408,8 @@ int CDGIdGateway::run()
 	CStopWatch stopWatch;
 	stopWatch.start();
 
-	LogMessage("Starting DGIdGateway-%s", VERSION);
+	LogMessage("DGIdGateway-%s is starting", VERSION);
+ 	LogMessage("Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	DGID_STATUS state = DS_NOTLINKED;
 	unsigned int nPips = 0U;

--- a/DGIdGateway/Makefile
+++ b/DGIdGateway/Makefile
@@ -23,9 +23,22 @@ DGIdGateway:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+DGIdGateway.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
 install:
 		install -m 755 DGIdGateway /usr/local/bin/
 
 clean:
-		$(RM) DGIdGateway *.o *.d *.bak *~
- 
+		$(RM) DGIdGateway *.o *.d *.bak *~ GitVersion.h
+
+GitVersion.h:
+ifneq ("$(wildcard ../.git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif
+

--- a/YSFGateway/Makefile
+++ b/YSFGateway/Makefile
@@ -22,9 +22,22 @@ YSFGateway:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+YSFGateway.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
 install:
 		install -m 755 YSFGateway /usr/local/bin/
 
 clean:
-		$(RM) YSFGateway *.o *.d *.bak *~
+		$(RM) YSFGateway *.o *.d *.bak *~ GitVersion.h
  
+# Export the current git version if the index file exists, else 000...
+GitVersion.h:
+ifneq ("$(wildcard ../.git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -25,6 +25,7 @@
 #include "Timer.h"
 #include "Utils.h"
 #include "Log.h"
+#include "GitVersion.h"
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
@@ -56,7 +57,7 @@ int main(int argc, char** argv)
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {
-				::fprintf(stdout, "YSFGateway version %s\n", VERSION);
+				::fprintf(stdout, "YSFGateway version %s git #%.7s\n", VERSION, gitversion);
 				return 0;
 			} else if (arg.substr(0, 1) == "-") {
 				::fprintf(stderr, "Usage: YSFGateway [-v|--version] [filename]\n");
@@ -266,7 +267,8 @@ int CYSFGateway::run()
 	CStopWatch stopWatch;
 	stopWatch.start();
 
-	LogMessage("Starting YSFGateway-%s", VERSION);
+	LogMessage("YSFGateway-%s is starting", VERSION);
+	LogMessage("Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	for (;;) {
 		unsigned char buffer[200U];

--- a/YSFParrot/Makefile
+++ b/YSFParrot/Makefile
@@ -14,9 +14,21 @@ YSFParrot:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+YSFParrot.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
 install:
 		install -m 755 YSFParrot /usr/local/bin/
 
 clean:
-		$(RM) YSFParrot *.o *.d *.bak *~
+		$(RM) YSFParrot *.o *.d *.bak *~ GitVersion.h
  
+GitVersion.h:
+ifneq ("$(wildcard ../.git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/YSFParrot/YSFParrot.cpp
+++ b/YSFParrot/YSFParrot.cpp
@@ -23,6 +23,7 @@
 #include "Version.h"
 #include "Thread.h"
 #include "Timer.h"
+#include "GitVersion.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -30,21 +31,29 @@
 
 int main(int argc, char** argv)
 {
-	if (argc == 1) {
-		::fprintf(stderr, "Usage: YSFParrot [-d|--debug] <port>\n");
-		return 1;
+	if (argc > 1) {
+		for (int currentArg = 1; currentArg < argc; ++currentArg) {
+			std::string arg = argv[currentArg];
+			if ((arg == "-v") || (arg == "--version")) {
+				::fprintf(stdout, "YSFParrot version %s git #%.7s\n", VERSION, gitversion);
+				return 0;
+			} else if (arg.substr(0, 1) == "-") {
+				::fprintf(stderr, "Usage: YSFParrot [-v|--version] [-d|--debug] <port>\n");
+				return 1;
+			} else {
+        			unsigned short port = (unsigned short)::atoi(argv[1U]);
+        			if (port == 0U) {
+                			::fprintf(stderr, "YSFParrot: invalid port number - %s\n", argv[1U]);
+                			return 1;
+        			}
+
+        			CYSFParrot parrot(port);
+        			parrot.run();
+
+ 			       return 0;
+			}
+		}
 	}
-
-	unsigned short port = (unsigned short)::atoi(argv[1U]);
-	if (port == 0U) {
-		::fprintf(stderr, "YSFParrot: invalid port number - %s\n", argv[1U]);
-		return 1;
-	}
-
-	CYSFParrot parrot(port);
-	parrot.run();
-
-	return 0;
 }
 
 CYSFParrot::CYSFParrot(unsigned short port) :
@@ -77,7 +86,8 @@ void CYSFParrot::run()
 	unsigned int count = 0U;
 	bool playing = false;
 
-	::fprintf(stdout, "Starting YSFParrot-%s\n", VERSION);
+	::fprintf(stdout, "YSFParrot-%s is starting", VERSION);
+	::fprintf(stdout, "Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	for (;;) {
 		unsigned char buffer[200U];

--- a/YSFReflector/Makefile
+++ b/YSFReflector/Makefile
@@ -14,9 +14,22 @@ YSFReflector:	$(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+YSFReflector.o: GitVersion.h FORCE
+
+.PHONY: GitVersion.h
+
+FORCE:
+
 install:
 		install -m 755 YSFReflector /usr/local/bin/
 
 clean:
-		$(RM) YSFReflector *.o *.d *.bak *~
+		$(RM) YSFReflector *.o *.d *.bak *~ GitVersion.h
  
+# Export the current git version if the index file exists, else 000...
+GitVersion.h:
+ifneq ("$(wildcard ../.git/index)","")
+	echo "const char *gitversion = \"$(shell git rev-parse HEAD)\";" > $@
+else
+	echo "const char *gitversion = \"0000000000000000000000000000000000000000\";" > $@
+endif

--- a/YSFReflector/YSFReflector.cpp
+++ b/YSFReflector/YSFReflector.cpp
@@ -23,6 +23,7 @@
 #include "Version.h"
 #include "Thread.h"
 #include "Log.h"
+#include "GitVersion.h"
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <Windows.h>
@@ -58,7 +59,7 @@ int main(int argc, char** argv)
 		for (int currentArg = 1; currentArg < argc; ++currentArg) {
 			std::string arg = argv[currentArg];
 			if ((arg == "-v") || (arg == "--version")) {
-				::fprintf(stdout, "YSFReflector version %s\n", VERSION);
+				::fprintf(stdout, "YSFReflector version %s git #%.7s\n", VERSION, gitversion);
 				return 0;
 			} else if (arg.substr(0, 1) == "-") {
 				::fprintf(stderr, "Usage: YSFReflector [-v|--version] [filename]\n");
@@ -191,7 +192,8 @@ void CYSFReflector::run()
 	CTimer pollTimer(1000U, 5U);
 	pollTimer.start();
 
-	LogMessage("Starting YSFReflector-%s", VERSION);
+	LogMessage("YSFReflector-%s is starting", VERSION);
+	LogMessage("Built %s %s (GitID #%.7s)", __TIME__, __DATE__, gitversion);
 
 	CTimer watchdogTimer(1000U, 0U, 1500U);
 


### PR DESCRIPTION
- Added git version string to VERSION, etc. (GitVersion.h); consistent with other clients.
- Added '--version|-v' to YSFParrot, as well as GitVersion.h facility
- Added GitVersion.h to gitignore