### PR TITLE
Add new remote command:

### DIFF
--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -977,6 +977,13 @@ void CYSFGateway::processRemoteCommands()
 				m_lostTimer.stop();
 				m_linkType = LINK_NONE;
 			}
+		} else if (::memcmp(buffer + 0U, "status", 6U) == 0) {
+			std::string state = std::string("ysf:") + (((m_ysfNetwork == NULL) && (m_fcsNetwork == NULL)) ? "n/a" : ((m_linkType != LINK_NONE) ? "conn" : "disc"));
+			m_remoteSocket->write((unsigned char*)state.c_str(), (unsigned int)state.length(), addr, addrLen);
+		} else if (::memcmp(buffer + 0U, "host", 4U) == 0) {
+			std::string ref = ((((m_ysfNetwork == NULL) && (m_fcsNetwork == NULL)) || (m_linkType == LINK_NONE)) ? "NONE" : m_current);
+			std::string host = std::string("ysf:\"") + ref + "\"";
+			m_remoteSocket->write((unsigned char*)host.c_str(), (unsigned int)host.length(), addr, addrLen);
 		} else {
 			CUtils::dump("Invalid remote command received", buffer, res);
 		}


### PR DESCRIPTION
 - status: displays network connection status (n/a, conn, disc), just like DMRGateway/MMDVMHost.
 - host: display connected host, or NONE if disconnected (surrounded with double quotes).

```
root@host:~ # RemoteCommand 6073 status
Command sent: "status" to port: 6073
ysf:conn
```

```
root@host:~ # RemoteCommand 6073 host
Command sent: "host" to port: 6073
ysf:"FR-YSF-France"
```