### PR TITLE
Dirty patch for compatibility with the Ft-991a (and maybe the FT-991)

### DIFF
--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -920,7 +920,7 @@ void CWiresX::sendSearchReply()
 	unsigned int n = search.size() - m_start;
 	if (n > 20U) n = 20U;
 
-	::sprintf((char*)(data + 23U), "%02u%03u", n, total);
+	::sprintf((char*)(data + 23U), "%02u%03u", 20U, total);
 
 	data[28U] = 0x0DU;
 
@@ -952,8 +952,16 @@ void CWiresX::sendSearchReply()
 
 	unsigned int k = 1029U - offset;
 	for(unsigned int i = 0U; i < k; i++)
-		data[i + offset] = 0x20U;
-
+ 	{
+		if (i % 50U == 49 && i>0)
+		{
+			data[i + offset] = 0x0DU;
+		}
+		else
+		{
+			data[i + offset] = 0x20U;
+		}
+	}
 	offset += k;
 
 	data[offset + 0U] = 0x03U;			// End of data marker

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -836,7 +836,7 @@ void CWiresX::sendAllReply()
 	unsigned int n = curr.size() - m_start;
 	if (n > 20U) n = 20U;
 
-	::sprintf((char*)(data + 22U), "%03u%03u", n, total);
+	::sprintf((char*)(data + 22U), "%03u%03u", 20U, total);
 
 	data[28U] = 0x0DU;
 
@@ -868,7 +868,16 @@ void CWiresX::sendAllReply()
 
 	unsigned int k = 1029U - offset;
 	for(unsigned int i = 0U; i < k; i++)
-		data[i + offset] = 0x20U;
+	{
+		if (i % 50U == 49 && i>0)
+		{
+			data[i + offset] = 0x0DU;
+		}
+		else
+		{
+			data[i + offset] = 0x20U;
+		}
+	}
 
 	offset += k;
 
@@ -1035,7 +1044,7 @@ void CWiresX::sendCategoryReply()
 	if (n > 20U)
 		n = 20U;
 
-	::sprintf((char*)(data + 22U), "%03u%03u", n, n);
+	::sprintf((char*)(data + 22U), "%03u%03u", 20U, n);
 
 	data[28U] = 0x0DU;
 
@@ -1067,7 +1076,16 @@ void CWiresX::sendCategoryReply()
 
 	unsigned int k = 1029U - offset;
 	for(unsigned int i = 0U; i < k; i++)
-		data[i + offset] = 0x20U;
+	{
+		if (i % 50U == 49 && i>0)
+		{
+			data[i + offset] = 0x0DU;
+		}
+		else
+		{
+			data[i + offset] = 0x20U;
+		}
+	}
 
 	offset += k;
 


### PR DESCRIPTION
The FT991 is very stupid when ie process the the search reply, the all reply and the group reply.
If the response did not contains 20 entry it display a "NO DATA" banner.

This patch solve the problem by filling the response with empty records and fix the number of records to 20.

The implementation is quick and dirty but working. Adding a parameter to activate the FT-991A compatibility mode  will be a better option but I don't have the energy to develop it

Hope that's may serve to others

With my best 73's
Olivier 
HB9TOB