### PR TITLE
Configuration parsing bugfix

### DIFF
--- a/DGIdGateway/Conf.cpp
+++ b/DGIdGateway/Conf.cpp
@@ -155,8 +155,8 @@ bool CConf::read()
 		char *p;
 
 		// if value is not quoted, remove after # (to make comment)
-		if ((p = strchr(value, '#')) != NULL)
-			*p = '\0';
+		if ((p = strchr(value, '#')) != NULL && p == value)
+		    *p = '\0';
 
 		// remove trailing tab/space
 		for (p = value + strlen(value) - 1U; p >= value && (*p == '\t' || *p == ' '); p--)

--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -160,8 +160,8 @@ bool CConf::read()
 		char *p;
 
 		// if value is not quoted, remove after # (to make comment)
-		if ((p = strchr(value, '#')) != NULL)
-			*p = '\0';
+		if ((p = strchr(value, '#')) != NULL && p == value)
+		    *p = '\0';
 
 		// remove trailing tab/space
 		for (p = value + strlen(value) - 1U; p >= value && (*p == '\t' || *p == ' '); p--)


### PR DESCRIPTION
Fixes configuration bug; when "Symbol=" value contains a valid APRS literal "#", it was parsed as a comment and not honored (now has more strict checking).