### PR TITLE
Update YSFGateway.cpp

### DIFF
--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -88,6 +88,8 @@ m_ysfNetworkYSF2NXDNAddress("127.0.0.1"),
 m_ysfNetworkYSF2NXDNPort(0U),
 m_ysfNetworkYSF2P25Address("127.0.0.1"),
 m_ysfNetworkYSF2P25Port(0U),
+m_ysfNetworkYSFDirectAddress("127.0.0.1"),
+m_ysfNetworkYSFDirectPort(0U),
 m_fcsNetworkEnabled(false),
 m_fcsNetworkFile(),
 m_fcsNetworkPort(0U),
@@ -274,6 +276,10 @@ bool CConf::read()
 			m_ysfNetworkYSF2P25Address = value;
 		else if (::strcmp(key, "YSF2P25Port") == 0)
 			m_ysfNetworkYSF2P25Port = (unsigned short)::atoi(value);
+        else if (::strcmp(key, "YSFDirectAddress") == 0)
+			m_ysfNetworkYSFDirectAddress = value;
+		else if (::strcmp(key, "YSFDirectPort") == 0)
+			m_ysfNetworkYSFDirectPort = (unsigned short)::atoi(value);    
 	} else if (section == SECTION_FCS_NETWORK) {
 		if (::strcmp(key, "Enable") == 0)
 			m_fcsNetworkEnabled = ::atoi(value) == 1;
@@ -534,6 +540,16 @@ std::string CConf::getYSFNetworkYSF2P25Address() const
 unsigned short CConf::getYSFNetworkYSF2P25Port() const
 {
 	return m_ysfNetworkYSF2P25Port;
+}
+
+std::string CConf::getYSFNetworkYSFDirectAddress() const
+{
+	return m_ysfNetworkYSFDirectAddress;
+}
+
+unsigned short CConf::getYSFNetworkYSFDirectPort() const
+{
+	return m_ysfNetworkYSFDirectPort;
 }
 
 

--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -276,7 +276,7 @@ bool CConf::read()
 			m_ysfNetworkYSF2P25Address = value;
 		else if (::strcmp(key, "YSF2P25Port") == 0)
 			m_ysfNetworkYSF2P25Port = (unsigned short)::atoi(value);
-        else if (::strcmp(key, "YSFDirectAddress") == 0)
+		else if (::strcmp(key, "YSFDirectAddress") == 0)
 			m_ysfNetworkYSFDirectAddress = value;
 		else if (::strcmp(key, "YSFDirectPort") == 0)
 			m_ysfNetworkYSFDirectPort = (unsigned short)::atoi(value);    

--- a/YSFGateway/Conf.h
+++ b/YSFGateway/Conf.h
@@ -87,6 +87,8 @@ public:
   unsigned short getYSFNetworkYSF2NXDNPort() const;
   std::string  getYSFNetworkYSF2P25Address() const;
   unsigned short getYSFNetworkYSF2P25Port() const;
+  std::string  getYSFNetworkYSFDirectAddress() const;
+  unsigned short getYSFNetworkYSFDirectPort() const;
 
   // The FCS Network section
   bool         getFCSNetworkEnabled() const;
@@ -156,6 +158,8 @@ private:
   unsigned short m_ysfNetworkYSF2NXDNPort;
   std::string  m_ysfNetworkYSF2P25Address;
   unsigned short m_ysfNetworkYSF2P25Port;
+  std::string  m_ysfNetworkYSFDirectAddress;
+  unsigned short m_ysfNetworkYSFDirectPort;
 
   bool         m_fcsNetworkEnabled;
   std::string  m_fcsNetworkFile;

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -378,11 +378,11 @@ WX_STATUS CWiresX::processConnect(const unsigned char* source, const unsigned ch
 
 	std::string id = std::string((char*)data, 5U);
 
-    CYSFReflector* reflector_tmp;
+	CYSFReflector* reflector_tmp;
 	reflector_tmp = m_reflectors.findById(id);
-    if (reflector_tmp != NULL)
-	    m_reflector = reflector_tmp;
-        
+	if (reflector_tmp != NULL)
+		m_reflector = reflector_tmp;
+
 	if (m_reflector == NULL)
 		return WXS_NONE;
 

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -173,6 +173,11 @@ void CWiresX::setYSF2P25(const std::string& address, unsigned short port)
 	m_reflectors.setYSF2P25(address, port);
 }
 
+void CWiresX::setYSFDirect(const std::string& address, unsigned short port)
+{
+	m_reflectors.setYSFDirect(address, port);
+}
+
 void CWiresX::addFCSRoom(const std::string& id, const std::string& name)
 {
 	m_reflectors.addFCSRoom(id, name);

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -373,7 +373,11 @@ WX_STATUS CWiresX::processConnect(const unsigned char* source, const unsigned ch
 
 	std::string id = std::string((char*)data, 5U);
 
-	m_reflector = m_reflectors.findById(id);
+    CYSFReflector* reflector_tmp;
+	reflector_tmp = m_reflectors.findById(id);
+    if (reflector_tmp != NULL)
+	    m_reflector = reflector_tmp;
+        
 	if (m_reflector == NULL)
 		return WXS_NONE;
 

--- a/YSFGateway/WiresX.h
+++ b/YSFGateway/WiresX.h
@@ -55,6 +55,7 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned short port);
 	void setYSF2NXDN(const std::string& address, unsigned short port);
 	void setYSF2P25(const std::string& address, unsigned short port);
+	void setYSFDirect(const std::string& address, unsigned short port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool start();

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -892,10 +892,11 @@ void CYSFGateway::processRemoteCommands()
 	int res = m_remoteSocket->read(buffer, 200U, addr, addrLen);
 	if (res > 0) {
 		buffer[res] = '\0';
-		if ((::memcmp(buffer + 0U, "LinkYSF", 7U) == 0) && (strlen((char*)buffer + 0U) > 8)) {
-			std::string id = std::string((char*)(buffer + 8U));
+		if ((::memcmp(buffer + 0U, "LinkYSF", 7U) == 0) && (strlen((char*)buffer + 0U) > 8) && (m_ysfNetwork != NULL)) {
+			std::string id = std::string((char*)(buffer + 7U));
 			// Left trim
-			id.erase(id.begin(), std::find_if(id.begin(), id.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+			// id.erase(id.begin(), std::find_if(id.begin(), id.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+            id.erase(std::remove_if(id.begin(), id.end(), [](char c) { return !std::isalnum(c); }), id.end());
 			CYSFReflector* reflector = m_reflectors->findById(id);
 			if (reflector == NULL)
 				reflector = m_reflectors->findByName(id);
@@ -923,10 +924,11 @@ void CYSFGateway::processRemoteCommands()
 				LogWarning("Invalid YSF reflector id/name - \"%s\"", id.c_str());
 				return;
 			}
-		} else if ((::memcmp(buffer + 0U, "LinkFCS", 7U) == 0) && (strlen((char*)buffer + 0U) > 8)) {
-			std::string raw = std::string((char*)(buffer + 8U));
+		} else if ((::memcmp(buffer + 0U, "LinkFCS", 7U) == 0) && (strlen((char*)buffer + 0U) > 8) && (m_fcsNetwork != NULL)) {
+			std::string raw = std::string((char*)(buffer + 7U));
 			// Left trim
-			raw.erase(raw.begin(), std::find_if(raw.begin(), raw.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+			// raw.erase(raw.begin(), std::find_if(raw.begin(), raw.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+            raw.erase(std::remove_if(raw.begin(), raw.end(), [](char c) { return !std::isalnum(c); }), raw.end());
 			std::string id = "FCS00";
 			std::string idShort = "FCS";
 			if (raw.length() == 3U) {

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -539,6 +539,11 @@ void CYSFGateway::createWiresX(CYSFNetwork* rptNetwork)
 	if (port > 0U)
 		m_wiresX->setYSF2P25(address, port);
 
+	address = m_conf.getYSFNetworkYSFDirectAddress();
+	port = m_conf.getYSFNetworkYSFDirectPort();
+	if (port > 0U)
+		m_wiresX->setYSFDirect(address, port);
+
 	std::string filename = m_conf.getFCSNetworkFile();
 	if (m_fcsNetworkEnabled)
 		readFCSRoomsFile(filename);
@@ -952,7 +957,7 @@ void CYSFGateway::processRemoteCommands()
 			m_current.clear();
 			m_inactivityTimer.stop();
 			m_lostTimer.stop();
-			m_linkType = LINK_NONE;
+			m_linkType = LINK_FCS;
 
 			LogMessage("Connect by remote command to %s", id.c_str());
 
@@ -961,7 +966,7 @@ void CYSFGateway::processRemoteCommands()
 				m_current = id;
 				m_inactivityTimer.start();
 				m_lostTimer.start();
-				m_linkType = LINK_FCS;
+				m_linkType = LINK_NONE;
 			} else {
 				LogMessage("Unknown reflector - %s", id.c_str());
 			}

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -283,10 +283,10 @@ int CYSFGateway::run()
 				unsigned char dt = fich.getDT();
 
 				CYSFReflector* reflector = m_wiresX->getReflector();
-                if (reflector != NULL)
-                    wx_tmp = reflector->m_wiresX;
-                else
-                    wx_tmp = 0;
+				if (reflector != NULL)
+					wx_tmp = reflector->m_wiresX;
+				else
+					wx_tmp = false;
 				if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wiresXCommandPassthrough && wx_tmp) {
 					processDTMF(buffer, dt);
 					processWiresX(buffer, fich, true, wiresXCommandPassthrough);
@@ -294,10 +294,10 @@ int CYSFGateway::run()
 					processDTMF(buffer, dt);
 					processWiresX(buffer, fich, false, wiresXCommandPassthrough);
 					reflector = m_wiresX->getReflector(); //reflector may have changed
-                if (reflector != NULL)
-                    wx_tmp = reflector->m_wiresX;
-                else
-                    wx_tmp = 0;
+					if (reflector != NULL)
+						wx_tmp = reflector->m_wiresX;
+					else
+						wx_tmp = false;
 					if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wx_tmp)
 						m_exclude = (dt == YSF_DT_DATA_FR_MODE);
 				}
@@ -840,7 +840,7 @@ void CYSFGateway::startupLinking()
 			m_linkType = LINK_NONE;
 
 			CYSFReflector* reflector = m_reflectors->findByName(m_startup);
-            if (reflector == NULL)
+			if (reflector == NULL)
 				reflector = m_reflectors->findById(m_startup);
 			if (reflector != NULL) {
 				LogMessage("Automatic (re-)connection to %5.5s - \"%s\"", reflector->m_id.c_str(), reflector->m_name.c_str());
@@ -903,7 +903,7 @@ void CYSFGateway::processRemoteCommands()
 			std::string id = std::string((char*)(buffer + 7U));
 			// Left trim
 			// id.erase(id.begin(), std::find_if(id.begin(), id.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-            id.erase(std::remove_if(id.begin(), id.end(), [](char c) { return !std::isalnum(c); }), id.end());
+			id.erase(std::remove_if(id.begin(), id.end(), [](char c) { return !std::isalnum(c); }), id.end());
 			CYSFReflector* reflector = m_reflectors->findById(id);
 			if (reflector == NULL)
 				reflector = m_reflectors->findByName(id);
@@ -935,7 +935,7 @@ void CYSFGateway::processRemoteCommands()
 			std::string raw = std::string((char*)(buffer + 7U));
 			// Left trim
 			// raw.erase(raw.begin(), std::find_if(raw.begin(), raw.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-            raw.erase(std::remove_if(raw.begin(), raw.end(), [](char c) { return !std::isalnum(c); }), raw.end());
+			raw.erase(std::remove_if(raw.begin(), raw.end(), [](char c) { return !std::isalnum(c); }), raw.end());
 			std::string id = "FCS00";
 			std::string idShort = "FCS";
 			if (raw.length() == 3U) {

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -273,7 +273,8 @@ int CYSFGateway::run()
 	for (;;) {
 		unsigned char buffer[200U];
 		memset(buffer, 0U, 200U);
-
+        bool wx_tmp;
+        
 		while (rptNetwork.read(buffer) > 0U) {
 			CYSFFICH fich;
 			bool valid = fich.decode(buffer + 35U);
@@ -282,14 +283,22 @@ int CYSFGateway::run()
 				unsigned char dt = fich.getDT();
 
 				CYSFReflector* reflector = m_wiresX->getReflector();
-				if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wiresXCommandPassthrough && reflector->m_wiresX) {
+                if (reflector != NULL)
+                    wx_tmp = reflector->m_wiresX;
+                else
+                    wx_tmp = 0;
+				if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wiresXCommandPassthrough && wx_tmp) {
 					processDTMF(buffer, dt);
 					processWiresX(buffer, fich, true, wiresXCommandPassthrough);
 				} else {
 					processDTMF(buffer, dt);
 					processWiresX(buffer, fich, false, wiresXCommandPassthrough);
 					reflector = m_wiresX->getReflector(); //reflector may have changed
-					if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && reflector->m_wiresX)
+                if (reflector != NULL)
+                    wx_tmp = reflector->m_wiresX;
+                else
+                    wx_tmp = 0;
+					if (m_ysfNetwork != NULL && m_linkType == LINK_YSF && wx_tmp)
 						m_exclude = (dt == YSF_DT_DATA_FR_MODE);
 				}
 

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -840,6 +840,8 @@ void CYSFGateway::startupLinking()
 			m_linkType = LINK_NONE;
 
 			CYSFReflector* reflector = m_reflectors->findByName(m_startup);
+            if (reflector == NULL)
+				reflector = m_reflectors->findById(m_startup);
 			if (reflector != NULL) {
 				LogMessage("Automatic (re-)connection to %5.5s - \"%s\"", reflector->m_id.c_str(), reflector->m_name.c_str());
 

--- a/YSFGateway/YSFGateway.ini
+++ b/YSFGateway/YSFGateway.ini
@@ -60,6 +60,8 @@ YSF2NXDNAddress=127.0.0.1
 YSF2NXDNPort=42014
 YSF2P25Address=127.0.0.1
 YSF2P25Port=42015
+YSFDirectAddress=127.0.0.1
+YSFDirectPort=42016
 
 [FCS Network]
 Enable=1

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -260,7 +260,7 @@ bool CYSFReflectors::load()
 		}
 	}
 
-    	// Add the YSFDirect entry
+	// Add the YSFDirect entry
 	if (m_YSFDirectPort > 0U) {
 		sockaddr_storage addr;
 		unsigned int addrLen;
@@ -283,8 +283,8 @@ bool CYSFReflectors::load()
 		}
 	}
 
-    
-    
+
+
 	unsigned int id = 9U;
 	for (std::vector<std::pair<std::string, std::string>>::const_iterator it1 = m_fcsRooms.cbegin(); it1 != m_fcsRooms.cend(); ++it1) {
 		bool used;

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -267,7 +267,7 @@ bool CYSFReflectors::load()
 		if (CUDPSocket::lookup(m_YSFDirectAddress, m_YSFDirectPort, addr, addrLen) == 0) {
 			CYSFReflector* refl = new CYSFReflector;
 			refl->m_id      = "00006";
-			refl->m_name    = "YSFDirect       ";
+			refl->m_name    = "YSFDIRECT       ";
 			refl->m_desc    = "Link YSFDirect";
 			refl->m_addr    = addr;
 			refl->m_addrLen = addrLen;

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -36,6 +36,8 @@ m_YSF2NXDNAddress(),
 m_YSF2NXDNPort(0U),
 m_YSF2P25Address(),
 m_YSF2P25Port(0U),
+m_YSFDirectAddress(),
+m_YSFDirectPort(0U),
 m_fcsRooms(),
 m_newReflectors(),
 m_currReflectors(),
@@ -98,6 +100,12 @@ void CYSFReflectors::setYSF2P25(const std::string& address, unsigned short port)
 {
 	m_YSF2P25Address = address;
 	m_YSF2P25Port    = port;
+}
+
+void CYSFReflectors::setYSFDirect(const std::string& address, unsigned short port)
+{
+	m_YSFDirectAddress = address;
+	m_YSFDirectPort    = port;
 }
 
 void CYSFReflectors::addFCSRoom(const std::string& id, const std::string& name)
@@ -252,6 +260,31 @@ bool CYSFReflectors::load()
 		}
 	}
 
+    	// Add the YSFDirect entry
+	if (m_YSFDirectPort > 0U) {
+		sockaddr_storage addr;
+		unsigned int addrLen;
+		if (CUDPSocket::lookup(m_YSFDirectAddress, m_YSFDirectPort, addr, addrLen) == 0) {
+			CYSFReflector* refl = new CYSFReflector;
+			refl->m_id      = "00006";
+			refl->m_name    = "YSFDirect       ";
+			refl->m_desc    = "Link YSFDirect";
+			refl->m_addr    = addr;
+			refl->m_addrLen = addrLen;
+			refl->m_count   = "000";
+			refl->m_type    = YT_YSF;
+			refl->m_wiresX  = true;
+
+			m_newReflectors.push_back(refl);
+
+			LogInfo("Loaded YSFDirect");
+		} else {
+			LogWarning("Unable to resolve the address of YSFDirect");
+		}
+	}
+
+    
+    
 	unsigned int id = 9U;
 	for (std::vector<std::pair<std::string, std::string>>::const_iterator it1 = m_fcsRooms.cbegin(); it1 != m_fcsRooms.cend(); ++it1) {
 		bool used;

--- a/YSFGateway/YSFReflectors.h
+++ b/YSFGateway/YSFReflectors.h
@@ -63,6 +63,7 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned short port);
 	void setYSF2NXDN(const std::string& address, unsigned short port);
 	void setYSF2P25(const std::string& address, unsigned short port);
+	void setYSFDirect(const std::string& address, unsigned short port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool load();
@@ -88,6 +89,8 @@ private:
 	unsigned short              m_YSF2NXDNPort;
 	std::string                 m_YSF2P25Address;
 	unsigned short              m_YSF2P25Port;
+	std::string                 m_YSFDirectAddress;
+	unsigned short              m_YSFDirectPort;
 	std::vector<std::pair<std::string, std::string>> m_fcsRooms;
 	std::vector<CYSFReflector*> m_newReflectors;
 	std::vector<CYSFReflector*> m_currReflectors;


### PR DESCRIPTION
Fixed the "segmentation fault" error in case a non-existent room is requested.

The error was due to the null pointer in "reflector" variable the case of non-existent room.