### PR TITLE
Reverses PR #306, which broke FCS Remote/Dynamic linking

### DIFF
--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -88,8 +88,6 @@ m_ysfNetworkYSF2NXDNAddress("127.0.0.1"),
 m_ysfNetworkYSF2NXDNPort(0U),
 m_ysfNetworkYSF2P25Address("127.0.0.1"),
 m_ysfNetworkYSF2P25Port(0U),
-m_ysfNetworkYSFDirectAddress("127.0.0.1"),
-m_ysfNetworkYSFDirectPort(0U),
 m_fcsNetworkEnabled(false),
 m_fcsNetworkFile(),
 m_fcsNetworkPort(0U),
@@ -276,10 +274,6 @@ bool CConf::read()
 			m_ysfNetworkYSF2P25Address = value;
 		else if (::strcmp(key, "YSF2P25Port") == 0)
 			m_ysfNetworkYSF2P25Port = (unsigned short)::atoi(value);
-		else if (::strcmp(key, "YSFDirectAddress") == 0)
-			m_ysfNetworkYSFDirectAddress = value;
-		else if (::strcmp(key, "YSFDirectPort") == 0)
-			m_ysfNetworkYSFDirectPort = (unsigned short)::atoi(value);    
 	} else if (section == SECTION_FCS_NETWORK) {
 		if (::strcmp(key, "Enable") == 0)
 			m_fcsNetworkEnabled = ::atoi(value) == 1;
@@ -540,16 +534,6 @@ std::string CConf::getYSFNetworkYSF2P25Address() const
 unsigned short CConf::getYSFNetworkYSF2P25Port() const
 {
 	return m_ysfNetworkYSF2P25Port;
-}
-
-std::string CConf::getYSFNetworkYSFDirectAddress() const
-{
-	return m_ysfNetworkYSFDirectAddress;
-}
-
-unsigned short CConf::getYSFNetworkYSFDirectPort() const
-{
-	return m_ysfNetworkYSFDirectPort;
 }
 
 

--- a/YSFGateway/Conf.h
+++ b/YSFGateway/Conf.h
@@ -87,8 +87,6 @@ public:
   unsigned short getYSFNetworkYSF2NXDNPort() const;
   std::string  getYSFNetworkYSF2P25Address() const;
   unsigned short getYSFNetworkYSF2P25Port() const;
-  std::string  getYSFNetworkYSFDirectAddress() const;
-  unsigned short getYSFNetworkYSFDirectPort() const;
 
   // The FCS Network section
   bool         getFCSNetworkEnabled() const;
@@ -158,8 +156,6 @@ private:
   unsigned short m_ysfNetworkYSF2NXDNPort;
   std::string  m_ysfNetworkYSF2P25Address;
   unsigned short m_ysfNetworkYSF2P25Port;
-  std::string  m_ysfNetworkYSFDirectAddress;
-  unsigned short m_ysfNetworkYSFDirectPort;
 
   bool         m_fcsNetworkEnabled;
   std::string  m_fcsNetworkFile;

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -173,11 +173,6 @@ void CWiresX::setYSF2P25(const std::string& address, unsigned short port)
 	m_reflectors.setYSF2P25(address, port);
 }
 
-void CWiresX::setYSFDirect(const std::string& address, unsigned short port)
-{
-	m_reflectors.setYSFDirect(address, port);
-}
-
 void CWiresX::addFCSRoom(const std::string& id, const std::string& name)
 {
 	m_reflectors.addFCSRoom(id, name);
@@ -378,11 +373,7 @@ WX_STATUS CWiresX::processConnect(const unsigned char* source, const unsigned ch
 
 	std::string id = std::string((char*)data, 5U);
 
-	CYSFReflector* reflector_tmp;
-	reflector_tmp = m_reflectors.findById(id);
-	if (reflector_tmp != NULL)
-		m_reflector = reflector_tmp;
-
+	m_reflector = m_reflectors.findById(id);
 	if (m_reflector == NULL)
 		return WXS_NONE;
 

--- a/YSFGateway/WiresX.h
+++ b/YSFGateway/WiresX.h
@@ -55,7 +55,6 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned short port);
 	void setYSF2NXDN(const std::string& address, unsigned short port);
 	void setYSF2P25(const std::string& address, unsigned short port);
-	void setYSFDirect(const std::string& address, unsigned short port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool start();

--- a/YSFGateway/YSFGateway.ini
+++ b/YSFGateway/YSFGateway.ini
@@ -60,8 +60,6 @@ YSF2NXDNAddress=127.0.0.1
 YSF2NXDNPort=42014
 YSF2P25Address=127.0.0.1
 YSF2P25Port=42015
-YSFDirectAddress=127.0.0.1
-YSFDirectPort=42016
 
 [FCS Network]
 Enable=1

--- a/YSFGateway/YSFReflectors.cpp
+++ b/YSFGateway/YSFReflectors.cpp
@@ -36,8 +36,6 @@ m_YSF2NXDNAddress(),
 m_YSF2NXDNPort(0U),
 m_YSF2P25Address(),
 m_YSF2P25Port(0U),
-m_YSFDirectAddress(),
-m_YSFDirectPort(0U),
 m_fcsRooms(),
 m_newReflectors(),
 m_currReflectors(),
@@ -100,12 +98,6 @@ void CYSFReflectors::setYSF2P25(const std::string& address, unsigned short port)
 {
 	m_YSF2P25Address = address;
 	m_YSF2P25Port    = port;
-}
-
-void CYSFReflectors::setYSFDirect(const std::string& address, unsigned short port)
-{
-	m_YSFDirectAddress = address;
-	m_YSFDirectPort    = port;
 }
 
 void CYSFReflectors::addFCSRoom(const std::string& id, const std::string& name)
@@ -259,31 +251,6 @@ bool CYSFReflectors::load()
 			LogWarning("Unable to resolve the address of YSF2P25");
 		}
 	}
-
-	// Add the YSFDirect entry
-	if (m_YSFDirectPort > 0U) {
-		sockaddr_storage addr;
-		unsigned int addrLen;
-		if (CUDPSocket::lookup(m_YSFDirectAddress, m_YSFDirectPort, addr, addrLen) == 0) {
-			CYSFReflector* refl = new CYSFReflector;
-			refl->m_id      = "00006";
-			refl->m_name    = "YSFDIRECT       ";
-			refl->m_desc    = "Link YSFDirect";
-			refl->m_addr    = addr;
-			refl->m_addrLen = addrLen;
-			refl->m_count   = "000";
-			refl->m_type    = YT_YSF;
-			refl->m_wiresX  = true;
-
-			m_newReflectors.push_back(refl);
-
-			LogInfo("Loaded YSFDirect");
-		} else {
-			LogWarning("Unable to resolve the address of YSFDirect");
-		}
-	}
-
-
 
 	unsigned int id = 9U;
 	for (std::vector<std::pair<std::string, std::string>>::const_iterator it1 = m_fcsRooms.cbegin(); it1 != m_fcsRooms.cend(); ++it1) {

--- a/YSFGateway/YSFReflectors.h
+++ b/YSFGateway/YSFReflectors.h
@@ -63,7 +63,6 @@ public:
 	void setYSF2DMR(const std::string& address, unsigned short port);
 	void setYSF2NXDN(const std::string& address, unsigned short port);
 	void setYSF2P25(const std::string& address, unsigned short port);
-	void setYSFDirect(const std::string& address, unsigned short port);
 	void addFCSRoom(const std::string& id, const std::string& name);
 
 	bool load();
@@ -89,8 +88,6 @@ private:
 	unsigned short              m_YSF2NXDNPort;
 	std::string                 m_YSF2P25Address;
 	unsigned short              m_YSF2P25Port;
-	std::string                 m_YSFDirectAddress;
-	unsigned short              m_YSFDirectPort;
 	std::vector<std::pair<std::string, std::string>> m_fcsRooms;
 	std::vector<CYSFReflector*> m_newReflectors;
 	std::vector<CYSFReflector*> m_currReflectors;


### PR DESCRIPTION
PR #306 introduces show-stopping issues with FCS reflectors not linking and "`Link has failed, polls lost`" errors; essentially leaving FCS non-functional for users that dynamically/remotely manage FCS links.

Reversing PR 306 restores full FCS dynamic/remote linking functionality.

More info and discovery from the downstream WPSD issue log:
https://repo.w0chp.net/WPSD-Dev/W0CHP-PiStar-Dash/issues/75