### PR TITLE
PR for #323 - cont.

### DIFF
--- a/YSFGateway/Conf.cpp
+++ b/YSFGateway/Conf.cpp
@@ -74,6 +74,7 @@ m_aprsSymbol("/r"),
 m_networkStartup(),
 m_networkOptions(),
 m_networkInactivityTimeout(0U),
+m_networkReconnect(false),
 m_networkRevert(false),
 m_networkDebug(false),
 m_ysfNetworkEnabled(false),
@@ -245,6 +246,8 @@ bool CConf::read()
 			m_networkOptions = value;
 		else if (::strcmp(key, "InactivityTimeout") == 0)
 			m_networkInactivityTimeout = (unsigned int)::atoi(value);
+		else if (::strcmp(key, "Reconnect") == 0)
+			m_networkReconnect = ::atoi(value) == 1;
 		else if (::strcmp(key, "Revert") == 0)
 			m_networkRevert = ::atoi(value) == 1;
 		else if (::strcmp(key, "Debug") == 0)
@@ -464,6 +467,11 @@ std::string CConf::getNetworkOptions() const
 unsigned int CConf::getNetworkInactivityTimeout() const
 {
 	return m_networkInactivityTimeout;
+}
+
+bool CConf::getNetworkReconnect() const
+{
+	return m_networkReconnect;
 }
 
 bool CConf::getNetworkRevert() const

--- a/YSFGateway/Conf.h
+++ b/YSFGateway/Conf.h
@@ -71,6 +71,7 @@ public:
   std::string  getNetworkStartup() const;
   std::string  getNetworkOptions() const;
   unsigned int getNetworkInactivityTimeout() const;
+  bool         getNetworkReconnect() const;
   bool         getNetworkRevert() const;
   bool         getNetworkDebug() const;
 
@@ -141,6 +142,7 @@ private:
   std::string  m_networkStartup;
   std::string  m_networkOptions;
   unsigned int m_networkInactivityTimeout;
+  bool         m_networkReconnect;
   bool         m_networkRevert;
   bool         m_networkDebug;
 

--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -68,6 +68,8 @@ private:
 	CUDPSocket*     m_remoteSocket;
 
 	void startupLinking();
+	void reconnectReflector(const std::string& nameOrId);
+	void disconnectCurrentReflector();
 	std::string calculateLocator();
 	void processWiresX(const unsigned char* buffer, const CYSFFICH& fich, bool dontProcessWiresXLocal, bool wiresXCommandPassthrough);
 	void processDTMF(unsigned char* buffer, unsigned char dt);

--- a/YSFGateway/YSFGateway.ini
+++ b/YSFGateway/YSFGateway.ini
@@ -44,6 +44,7 @@ Suffix=Y
 # book DG-ID for Reflector
 # Options=20;21;
 InactivityTimeout=10
+Reconnect=0
 Revert=0
 Debug=0
 


### PR DESCRIPTION
  - Add "Reconnect=0" configuration option to the [Network] section to avoid ambiguity
  - Keep the original behaviors when Revert=1 and Reconnect=1
  - Bugfix on Wires-DX reconnect (find reflector both by id and name)