### PR TITLE
Update WiresX.cpp

### DIFF
--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <cassert>
 #include <cstdlib>
+#include <cctype>
 
 const unsigned char DX_REQ[]    = {0x5DU, 0x71U, 0x5FU};
 const unsigned char CONN_REQ[]  = {0x5DU, 0x23U, 0x5FU};
@@ -945,7 +946,7 @@ void CWiresX::sendSearchReply()
 			data[i + offset + 1U] = refl->m_id.at(i);
 
 		for (unsigned int i = 0U; i < 16U; i++)
-			data[i + offset + 6U] = refl->m_name.at(i);
+			data[i + offset + 6U] = std::toupper(refl->m_name.at(i));
 
 		for (unsigned int i = 0U; i < 3U; i++)
 			data[i + offset + 22U] = refl->m_count.at(i);

--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -853,7 +853,7 @@ void CWiresX::sendAllReply()
 			data[i + offset + 1U] = refl->m_id.at(i);
 
 		for (unsigned int i = 0U; i < 16U; i++)
-			data[i + offset + 6U] = refl->m_name.at(i);
+			data[i + offset + 6U] = std::toupper(refl->m_name.at(i));
 
 		for (unsigned int i = 0U; i < 3U; i++)
 			data[i + offset + 22U] = refl->m_count.at(i);


### PR DESCRIPTION
During WiresX mode Search, the reflector name should be Upper Case - this only matters during search - the normal display of the data can be mixed case. @g4klx if you have a better way to do this please adjust this, or can the pull and I'll see if I can do this better. The intended impact is ONLY the data sent to the radio as part of a search.