### PR TITLE
Match YSFGateway state with Radio State

### DIFF
--- a/YSFGateway/WiresX.cpp
+++ b/YSFGateway/WiresX.cpp
@@ -376,8 +376,11 @@ WX_STATUS CWiresX::processConnect(const unsigned char* source, const unsigned ch
 
 	m_reflector = m_reflectors.findById(id);
 	if (m_reflector == nullptr) {
+		if(source != nullptr)
+			processDisconnect(source);
 		sendConnectFailedReply();
-		return WX_STATUS::NONE;
+		// Keep state on Radio matched with YSFGateway
+		return WX_STATUS::DISCONNECT;
 	}
 
 	m_status = WXSI_STATUS::CONNECT;


### PR DESCRIPTION
when the radio is told the connection failed (by searching for a non existent reflector by ID for example), it assumes there is NO connection available any more, so YSFGateway should drop the active reflector connection to maintain the state that the radio assumes to be correct.

Continued improvement of the code changes in relation to #330