### PR TITLE
YSFGateway and DGIdGateway: retry YSFI after first YSFP handshake

### DIFF
--- a/DGIdGateway/DGIdGateway.cpp
+++ b/DGIdGateway/DGIdGateway.cpp
@@ -308,7 +308,9 @@ int CDGIdGateway::run()
 
 			CYSFReflector* reflector = reflectors->findByName(name);
 			if (reflector != nullptr) {
-				dgIdNetwork[dgid] = new CYSFNetwork(local, *reflector, m_callsign, statc, debug);
+				CYSFNetwork* ysfNetwork = new CYSFNetwork(local, *reflector, m_callsign, statc, debug);
+				ysfNetwork->setInfo(m_conf.getRxFrequency(), m_conf.getTxFrequency(), calculateLocator(), m_callsign, "MMDVM", m_conf.getId());
+				dgIdNetwork[dgid] = ysfNetwork;
 				dgIdNetwork[dgid]->m_modes       = DT_VD_MODE1 | DT_VD_MODE2 | DT_VOICE_FR_MODE | DT_DATA_FR_MODE;
 				dgIdNetwork[dgid]->m_static      = statc;
 				dgIdNetwork[dgid]->m_rfHangTime  = rfHangTime;
@@ -356,7 +358,9 @@ int CDGIdGateway::run()
 			sockaddr_storage addr;
 			unsigned int     addrLen;
 			if (CUDPSocket::lookup(it1->m_address, it1->m_port, addr, addrLen) == 0) {
-				dgIdNetwork[dgid] = new CYSFNetwork(local, "YSFGateway", addr, addrLen, m_callsign, statc, debug);
+				CYSFNetwork* ysfNetwork = new CYSFNetwork(local, "YSFGateway", addr, addrLen, m_callsign, statc, debug);
+				ysfNetwork->setInfo(m_conf.getRxFrequency(), m_conf.getTxFrequency(), calculateLocator(), m_callsign, "MMDVM", m_conf.getId());
+				dgIdNetwork[dgid] = ysfNetwork;
 				dgIdNetwork[dgid]->m_modes       = DT_VD_MODE1 | DT_VD_MODE2 | DT_VOICE_FR_MODE | DT_DATA_FR_MODE;
 				dgIdNetwork[dgid]->m_static      = statc;
 				dgIdNetwork[dgid]->m_rfHangTime  = rfHangTime;
@@ -373,7 +377,9 @@ int CDGIdGateway::run()
 			sockaddr_storage addr;
 			unsigned int     addrLen;
 			if (CUDPSocket::lookup(it1->m_address, it1->m_port, addr, addrLen) == 0) {
-				dgIdNetwork[dgid] = new CYSFNetwork(local, "PARROT", addr, addrLen, m_callsign, statc, debug);
+				CYSFNetwork* ysfNetwork = new CYSFNetwork(local, "PARROT", addr, addrLen, m_callsign, statc, debug);
+				ysfNetwork->setInfo(m_conf.getRxFrequency(), m_conf.getTxFrequency(), calculateLocator(), m_callsign, "MMDVM", m_conf.getId());
+				dgIdNetwork[dgid] = ysfNetwork;
 				dgIdNetwork[dgid]->m_modes       = DT_VD_MODE1 | DT_VD_MODE2 | DT_VOICE_FR_MODE | DT_DATA_FR_MODE;
 				dgIdNetwork[dgid]->m_static      = statc;
 				dgIdNetwork[dgid]->m_rfHangTime  = rfHangTime;

--- a/DGIdGateway/YSFNetwork.cpp
+++ b/DGIdGateway/YSFNetwork.cpp
@@ -27,6 +27,20 @@
 
 const unsigned int BUFFER_LENGTH = 200U;
 
+static void copyPadded(unsigned char* dest, const std::string& src, unsigned int length)
+{
+	::memset(dest, ' ', length);
+	size_t copyLength = src.size() < length ? src.size() : length;
+	::memcpy(dest, src.c_str(), copyLength);
+}
+
+static void copyNumber(unsigned char* dest, unsigned int value, unsigned int length)
+{
+	char buffer[20U];
+	::sprintf(buffer, "%0*u", int(length), value);
+	::memcpy(dest, buffer, length);
+}
+
 CYSFNetwork::CYSFNetwork(const std::string& localAddress, unsigned short localPort, const std::string& name, const sockaddr_storage& addr, unsigned int addrLen, const std::string& callsign, bool debug) :
 m_socket(localAddress, localPort),
 m_debug(debug),
@@ -38,7 +52,14 @@ m_buffer(1000U, "YSF Network Buffer"),
 m_sendPollTimer(1000U, 5U),
 m_recvPollTimer(1000U, 60U),
 m_state(DGID_STATUS::NOTOPEN),
-m_ipV6(false)
+m_ipV6(false),
+m_ysfInfoPending(false),
+m_rxFrequency(0U),
+m_txFrequency(0U),
+m_locator(),
+m_name(),
+m_type(),
+m_id(0U)
 {
 	m_reflector.m_id   = "99999";
 	m_reflector.m_name = "Local";
@@ -84,7 +105,14 @@ m_buffer(1000U, "YSF Network Buffer"),
 m_sendPollTimer(1000U, 5U),
 m_recvPollTimer(1000U, 60U),
 m_state(DGID_STATUS::NOTOPEN),
-m_ipV6(false)
+m_ipV6(false),
+m_ysfInfoPending(false),
+m_rxFrequency(0U),
+m_txFrequency(0U),
+m_locator(),
+m_name(),
+m_type(),
+m_id(0U)
 {
 	m_reflector.m_id   = "99999";
 	m_reflector.m_name = name;
@@ -130,7 +158,14 @@ m_buffer(1000U, "YSF Network Buffer"),
 m_sendPollTimer(1000U, 5U),
 m_recvPollTimer(1000U, 60U),
 m_state(DGID_STATUS::NOTOPEN),
-m_ipV6(false)
+m_ipV6(false),
+m_ysfInfoPending(false),
+m_rxFrequency(0U),
+m_txFrequency(0U),
+m_locator(),
+m_name(),
+m_type(),
+m_id(0U)
 {
 	m_poll = new unsigned char[14U];
 	::memcpy(m_poll + 0U, "YSFP", 4U);
@@ -197,6 +232,16 @@ DGID_STATUS CYSFNetwork::getStatus()
 	return m_state;
 }
 
+void CYSFNetwork::setInfo(unsigned int rxFrequency, unsigned int txFrequency, const std::string& locator, const std::string& name, const std::string& type, unsigned int id)
+{
+	m_rxFrequency = rxFrequency;
+	m_txFrequency = txFrequency;
+	m_locator     = locator;
+	m_name        = name;
+	m_type        = type;
+	m_id          = id;
+}
+
 void CYSFNetwork::write(unsigned int dgid, const unsigned char* data)
 {
 	assert(data != nullptr);
@@ -219,11 +264,13 @@ void CYSFNetwork::link()
 		return;
 
 	m_state = DGID_STATUS::LINKING;
+	m_ysfInfoPending = true;
 
 	m_sendPollTimer.start();
 	m_recvPollTimer.start();
 
 	writePoll();
+	writeInfo();
 }
 
 void CYSFNetwork::writePoll()
@@ -238,6 +285,31 @@ void CYSFNetwork::writePoll()
 		m_socket.write(m_poll, 14U, m_reflector.IPv6.m_addr, m_reflector.IPv6.m_addrLen);
 	else
 		m_socket.write(m_poll, 14U, m_reflector.IPv4.m_addr, m_reflector.IPv4.m_addrLen);
+}
+
+void CYSFNetwork::writeInfo()
+{
+	if (m_name.empty() && m_type.empty())
+		return;
+
+	unsigned char info[80U];
+	::memset(info, ' ', 80U);
+	::memcpy(info + 0U, "YSFI", 4U);
+	::memcpy(info + 4U, m_poll + 4U, YSF_CALLSIGN_LENGTH);
+	copyNumber(info + 14U, m_rxFrequency, 9U);
+	copyNumber(info + 23U, m_txFrequency, 9U);
+	copyPadded(info + 32U, m_locator, 6U);
+	copyPadded(info + 38U, m_name, 20U);
+	copyPadded(info + 58U, m_type, 12U);
+	copyNumber(info + 70U, m_id, 7U);
+
+	if (m_debug)
+		CUtils::dump(1U, "YSF Network Data Sent", info, 80U);
+
+	if (m_ipV6)
+		m_socket.write(info, 80U, m_reflector.IPv6.m_addr, m_reflector.IPv6.m_addrLen);
+	else
+		m_socket.write(info, 80U, m_reflector.IPv4.m_addr, m_reflector.IPv4.m_addrLen);
 }
 
 void CYSFNetwork::unlink()
@@ -308,6 +380,11 @@ void CYSFNetwork::clock(unsigned int ms)
 
 	if (::memcmp(buffer, "YSFP", 4U) == 0) {
 		m_recvPollTimer.start();
+
+		if (m_ysfInfoPending) {
+			writeInfo();
+			m_ysfInfoPending = false;
+		}
 
 		if (m_state == DGID_STATUS::LINKING) {
 			if (strcmp(m_reflector.m_name.c_str(), "MMDVM") == 0)

--- a/DGIdGateway/YSFNetwork.h
+++ b/DGIdGateway/YSFNetwork.h
@@ -56,6 +56,8 @@ public:
 
 	virtual void close();
 
+	void setInfo(unsigned int rxFrequency, unsigned int txFrequency, const std::string& locator, const std::string& name, const std::string& type, unsigned int id);
+
 private:
 	CUDPSocket                 m_socket;
 	bool                       m_debug;
@@ -68,8 +70,16 @@ private:
 	CTimer                     m_recvPollTimer;
 	DGID_STATUS                m_state;
 	bool                       m_ipV6;
+	bool                       m_ysfInfoPending;
+	unsigned int               m_rxFrequency;
+	unsigned int               m_txFrequency;
+	std::string                m_locator;
+	std::string                m_name;
+	std::string                m_type;
+	unsigned int               m_id;
 
 	void writePoll();
+	void writeInfo();
 };
 
 #endif

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -145,7 +145,8 @@ m_options(),
 m_exclude(false),
 m_inactivityTimer(1000U),
 m_lostTimer(1000U, 120U),
-m_fcsNetworkEnabled(false)
+m_fcsNetworkEnabled(false),
+m_ysfInfoPending(false)
 {
 	CUDPSocket::startup();
 }
@@ -362,6 +363,11 @@ int CYSFGateway::run()
 		if (m_ysfNetwork != nullptr) {
 			while (m_ysfNetwork->read(buffer) > 0U) {
 				if (m_linkType == LINK_TYPE::YSF) {
+					if (::memcmp(buffer + 0U, "YSFP", 4U) == 0 && m_ysfInfoPending) {
+						writeYSFInfo();
+						m_ysfInfoPending = false;
+					}
+
 					// Only pass through YSF data packets
 					if (::memcmp(buffer + 0U, "YSFD", 4U) == 0 && !m_wiresX->isBusy())
 						rptNetwork.write(buffer);
@@ -428,6 +434,7 @@ int CYSFGateway::run()
 				LogWarning("Link has failed, polls lost");
 				m_wiresX->processDisconnect();
 				m_ysfNetwork->clearDestination();
+				m_ysfInfoPending = false;
 			}
 
 			if (m_fcsNetwork != nullptr) {
@@ -594,6 +601,7 @@ void CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fic
 			writeJSONLinking("user", "ysf", reflector->m_name);
 
 			m_ysfNetwork->setDestination(*reflector);
+			m_ysfInfoPending = true;
 			m_ysfNetwork->writePoll(3U);
 			writeYSFInfo();
 
@@ -614,6 +622,7 @@ void CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fic
 				writeJSONUnlinked("user");
 				m_ysfNetwork->writeUnlink(3U);
 				m_ysfNetwork->clearDestination();
+				m_ysfInfoPending = false;
 			}
 
 			if (m_linkType == LINK_TYPE::FCS) {
@@ -655,6 +664,7 @@ void CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fic
 			writeJSONUnlinked("user");
 			m_ysfNetwork->writeUnlink(3U);
 			m_ysfNetwork->clearDestination();
+			m_ysfInfoPending = false;
 
 			m_current.clear();
 			m_inactivityTimer.start();
@@ -720,6 +730,7 @@ void CYSFGateway::processDTMF(unsigned char* buffer, unsigned char dt)
 				writeJSONLinking("user", "ysf", reflector->m_name);
 
 				m_ysfNetwork->setDestination(*reflector);
+				m_ysfInfoPending = true;
 				m_ysfNetwork->writePoll(3U);
 				writeYSFInfo();
 
@@ -751,6 +762,7 @@ void CYSFGateway::processDTMF(unsigned char* buffer, unsigned char dt)
 				m_wiresX->processDisconnect();
 				m_ysfNetwork->writeUnlink(3U);
 				m_ysfNetwork->clearDestination();
+				m_ysfInfoPending = false;
 			}
 
 			if (m_linkType == LINK_TYPE::FCS) {
@@ -787,6 +799,7 @@ void CYSFGateway::processDTMF(unsigned char* buffer, unsigned char dt)
 
 			m_ysfNetwork->writeUnlink(3U);
 			m_ysfNetwork->clearDestination();
+			m_ysfInfoPending = false;
 
 			m_current.clear();
 			m_inactivityTimer.start();
@@ -901,6 +914,7 @@ void CYSFGateway::startupLinking(const std::string& reason)
 				m_wiresX->setReflector(reflector);
 
 				m_ysfNetwork->setDestination(*reflector);
+				m_ysfInfoPending = true;
 				m_ysfNetwork->writePoll(3U);
 				writeYSFInfo();
 
@@ -950,6 +964,7 @@ void CYSFGateway::reconnectReflector(const std::string& reason, const std::strin
 			m_ysfNetwork->setDestination(*reflector);
 
 			m_ysfNetwork->setOptions(m_options);
+			m_ysfInfoPending = true;
 			m_ysfNetwork->writePoll(3U);
 			writeYSFInfo();
 
@@ -965,6 +980,7 @@ void CYSFGateway::disconnectCurrentReflector() {
 		m_wiresX->processDisconnect();
 		m_ysfNetwork->writeUnlink(3U);
 		m_ysfNetwork->clearDestination();
+		m_ysfInfoPending = false;
 	}
 
 	if (m_linkType == LINK_TYPE::FCS) {
@@ -1034,6 +1050,7 @@ void CYSFGateway::writeCommand(const std::string& command)
 			writeJSONLinking("remote", "ysf", reflector->m_name);
 
 				m_ysfNetwork->setDestination(*reflector);
+				m_ysfInfoPending = true;
 				m_ysfNetwork->writePoll(3U);
 				writeYSFInfo();
 
@@ -1069,6 +1086,7 @@ void CYSFGateway::writeCommand(const std::string& command)
 			m_wiresX->processDisconnect();
 			m_ysfNetwork->writeUnlink(3U);
 			m_ysfNetwork->clearDestination();
+			m_ysfInfoPending = false;
 		}
 
 		if (m_linkType == LINK_TYPE::FCS) {
@@ -1103,6 +1121,7 @@ void CYSFGateway::writeCommand(const std::string& command)
 
 			m_ysfNetwork->writeUnlink(3U);
 			m_ysfNetwork->clearDestination();
+			m_ysfInfoPending = false;
 
 			m_current.clear();
 			m_inactivityTimer.stop();

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -511,6 +511,20 @@ void CYSFGateway::createGPS()
 	m_gps = new CGPS(m_writer);
 }
 
+void CYSFGateway::writeYSFInfo()
+{
+	if (m_ysfNetwork == nullptr)
+		return;
+
+	unsigned int rxFrequency = m_conf.getRxFrequency();
+	unsigned int txFrequency = m_conf.getTxFrequency();
+	std::string locator = calculateLocator();
+	std::string name = m_conf.getName();
+	unsigned int id = m_conf.getId();
+
+	m_ysfNetwork->writeInfo(rxFrequency, txFrequency, locator, name, "MMDVM", id);
+}
+
 void CYSFGateway::createWiresX(CYSFNetwork* rptNetwork)
 {
 	assert(rptNetwork != nullptr);
@@ -581,6 +595,7 @@ void CYSFGateway::processWiresX(const unsigned char* buffer, const CYSFFICH& fic
 
 			m_ysfNetwork->setDestination(*reflector);
 			m_ysfNetwork->writePoll(3U);
+			writeYSFInfo();
 
 			m_current = reflector->m_id;
 			m_inactivityTimer.start();
@@ -706,6 +721,7 @@ void CYSFGateway::processDTMF(unsigned char* buffer, unsigned char dt)
 
 				m_ysfNetwork->setDestination(*reflector);
 				m_ysfNetwork->writePoll(3U);
+				writeYSFInfo();
 
 				m_current = id;
 				m_inactivityTimer.start();
@@ -886,6 +902,7 @@ void CYSFGateway::startupLinking(const std::string& reason)
 
 				m_ysfNetwork->setDestination(*reflector);
 				m_ysfNetwork->writePoll(3U);
+				writeYSFInfo();
 
 				m_current = m_startup;
 				m_inactivityTimer.start();
@@ -934,6 +951,7 @@ void CYSFGateway::reconnectReflector(const std::string& reason, const std::strin
 
 			m_ysfNetwork->setOptions(m_options);
 			m_ysfNetwork->writePoll(3U);
+			writeYSFInfo();
 
 			m_inactivityTimer.start();
 			m_lostTimer.start();
@@ -1017,6 +1035,7 @@ void CYSFGateway::writeCommand(const std::string& command)
 
 				m_ysfNetwork->setDestination(*reflector);
 				m_ysfNetwork->writePoll(3U);
+				writeYSFInfo();
 
 			m_current = id;
 			m_inactivityTimer.start();

--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -65,6 +65,7 @@ private:
 	CTimer          m_inactivityTimer;
 	CTimer          m_lostTimer;
 	bool            m_fcsNetworkEnabled;
+	bool            m_ysfInfoPending;
 
 	void startupLinking(const std::string& reason);
 	void reconnectReflector(const std::string& reason, const std::string& nameOrId);

--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -74,6 +74,7 @@ private:
 	void processDTMF(unsigned char* buffer, unsigned char dt);
 	void createWiresX(CYSFNetwork* rptNetwork);
 	void createGPS();
+	void writeYSFInfo();
 	void readFCSRoomsFile(const std::string& filename);
 
 	void writeJSONStatus(const std::string& status);

--- a/YSFGateway/YSFNetwork.cpp
+++ b/YSFGateway/YSFNetwork.cpp
@@ -27,6 +27,20 @@
 
 const unsigned int BUFFER_LENGTH = 200U;
 
+static void copyPadded(unsigned char* dest, const std::string& src, unsigned int length)
+{
+	::memset(dest, ' ', length);
+	size_t copyLength = src.size() < length ? src.size() : length;
+	::memcpy(dest, src.c_str(), copyLength);
+}
+
+static void copyNumber(unsigned char* dest, unsigned int value, unsigned int length)
+{
+	char buffer[20U];
+	::sprintf(buffer, "%0*u", int(length), value);
+	::memcpy(dest, buffer, length);
+}
+
 CYSFNetwork::CYSFNetwork(const std::string& address, unsigned short port, const std::string& callsign, bool debug) :
 m_socket(address, port),
 m_debug(debug),
@@ -234,6 +248,31 @@ void CYSFNetwork::setOptions(const std::string& options)
 
 	for (unsigned int i = 0U; i < (50U - 4U - YSF_CALLSIGN_LENGTH); i++)
 		m_options[i + 4U + YSF_CALLSIGN_LENGTH] = m_opt.at(i);
+}
+
+void CYSFNetwork::writeInfo(unsigned int rxFrequency, unsigned int txFrequency, const std::string& locator, const std::string& name, const std::string& type, unsigned int id)
+{
+	if (m_reflector.isEmpty())
+		return;
+
+	unsigned char info[80U];
+	::memset(info, ' ', 80U);
+	::memcpy(info + 0U, "YSFI", 4U);
+	::memcpy(info + 4U, m_poll + 4U, YSF_CALLSIGN_LENGTH);
+	copyNumber(info + 14U, rxFrequency, 9U);
+	copyNumber(info + 23U, txFrequency, 9U);
+	copyPadded(info + 32U, locator, 6U);
+	copyPadded(info + 38U, name, 20U);
+	copyPadded(info + 58U, type, 12U);
+	copyNumber(info + 70U, id, 7U);
+
+	if (m_debug)
+		CUtils::dump(1U, "YSF Network Data Sent", info, 80U);
+
+	if (m_ipV6)
+		m_socket.write(info, 80U, m_reflector.IPv6.m_addr, m_reflector.IPv6.m_addrLen);
+	else
+		m_socket.write(info, 80U, m_reflector.IPv4.m_addr, m_reflector.IPv4.m_addrLen);
 }
 
 void CYSFNetwork::writeUnlink(unsigned int count)

--- a/YSFGateway/YSFNetwork.h
+++ b/YSFGateway/YSFNetwork.h
@@ -42,6 +42,7 @@ public:
 
 	void writePoll(unsigned int count = 1U);
 	void setOptions(const std::string& options = "");
+	void writeInfo(unsigned int rxFrequency, unsigned int txFrequency, const std::string& locator, const std::string& name, const std::string& type, unsigned int id);
 	void writeUnlink(unsigned int count = 1U);
 
 	unsigned int read(unsigned char* data);


### PR DESCRIPTION
## Summary
This PR makes YSFI transmission more robust during YSF link setup in both YSFGateway and DGIdGateway.

## Problem
YSFI (info frame) was sent only once immediately after the initial polls during link setup. If that first YSFI arrived too early or was lost, reflector dashboards could show missing or incorrect repeater information even though the link itself was established.

DGIdGateway also did not build and send the 80-byte YSFI station information frame for its YSF network connections.

## What was changed
- Added a pending flag to track whether YSFI still needs a post-handshake retry.
- Set the pending flag when starting a YSF link.
- On the first inbound YSFP response, resend YSFI once and clear the pending flag.
- Clear the YSFGateway pending flag on unlink, disconnect, and destination-clear paths.
- Added YSFI station information generation to DGIdGateway YSF connections using callsign, frequencies, locator, type, and ID.
- Applied the DGIdGateway station information to YSF reflector, gateway, and parrot network instances.

## Why this works
YSFP confirms that the remote side is present and the session is active. Sending YSFI once more at that point delivers the information frame during the confirmed handshake window.

## Validation
- `make -C YSFGateway`
- `make -C DGIdGateway`
- Live YCS262 test: the server replied with YSFP, DGIdGateway resent YSFI, and logged `Linked to DE-C4FM`.
- Verified the YSFI payload carried the configured test callsign.

## Scope
Changed files:
- `YSFGateway/YSFGateway.h`
- `YSFGateway/YSFGateway.cpp`
- `DGIdGateway/DGIdGateway.cpp`
- `DGIdGateway/YSFNetwork.h`
- `DGIdGateway/YSFNetwork.cpp`

No YSF protocol field layout changes were made.