### PR TITLE
MQTT link status enrichment

### DIFF
--- a/DGIdGateway/DGIdGateway.cpp
+++ b/DGIdGateway/DGIdGateway.cpp
@@ -498,7 +498,7 @@ int CDGIdGateway::run()
 						currentDGId = dgId;
 						state = DGID_STATUS::NOTLINKED;
 					} else {
-						writeJSONUnlinked("user");
+						writeJSONFailed("user", dgId);
 						LogMessage("DG-ID set to %u (None) via RF", dgId);
 						state = DGID_STATUS::NOTOPEN;
 					}
@@ -794,6 +794,27 @@ void CDGIdGateway::writeJSONUnlinked(const std::string& reason)
 	json["timestamp"] = CUtils::createTimestamp();
 	json["action"]    = "unlinked";
 	json["reason"]    = reason;
+
+	WriteJSON("link", json, true);
+}
+
+// "failed" was already declared in schema.json's action enum but never
+// actually published. The real bug this fixes: selecting an RF DG-ID
+// that has no configured network mapping was previously reported as
+// "unlinked" -- which is wrong, not just incomplete. Nothing was ever
+// linked, so there's nothing to *un*link; this is a failed link attempt
+// (the DG-ID equivalent of DMR's wrong password or P25's unresolved
+// talkgroup -- a mistyped/unconfigured DG-ID is the likeliest real
+// operator mistake here), and deserves its own distinct signal rather
+// than being indistinguishable from a normal disconnect.
+void CDGIdGateway::writeJSONFailed(const std::string& reason, unsigned int id)
+{
+	nlohmann::json json;
+
+	json["timestamp"] = CUtils::createTimestamp();
+	json["action"]    = "failed";
+	json["reason"]    = reason;
+	json["dg-id"]     = int(id);
 
 	WriteJSON("link", json, true);
 }

--- a/DGIdGateway/DGIdGateway.h
+++ b/DGIdGateway/DGIdGateway.h
@@ -47,6 +47,7 @@ private:
 	void writeJSONStatus(const std::string& status);
 	void writeJSONLinking(const std::string& reason, unsigned int id, const std::string& protocol, const std::string& description);
 	void writeJSONUnlinked(const std::string& reason);
+	void writeJSONFailed(const std::string& reason, unsigned int id);
 };
 
 #endif

--- a/DGIdGateway/schema.json
+++ b/DGIdGateway/schema.json
@@ -21,7 +21,7 @@
 		"reason": {"$ref": "#/$defs/reason"},
 		"dg-id": {"$ref": "#/defs/dg-id"},
 		"protocol": {"$ref": "#/defs/protocol"},
-		"descrption": {"type": "string"},
+		"description": {"type": "string"},
 		"required": ["timestamp", "action"]
 	}
 }

--- a/YSFGateway/YSFGateway.cpp
+++ b/YSFGateway/YSFGateway.cpp
@@ -426,12 +426,14 @@ int CYSFGateway::run()
 		if (m_lostTimer.isRunning() && m_lostTimer.hasExpired()) {
 			if (m_linkType == LINK_TYPE::YSF) {
 				LogWarning("Link has failed, polls lost");
+				writeJSONFailed("timer", m_current);
 				m_wiresX->processDisconnect();
 				m_ysfNetwork->clearDestination();
 			}
 
 			if (m_fcsNetwork != nullptr) {
 				LogWarning("Link has failed, polls lost");
+				writeJSONFailed("timer", m_current);
 				m_fcsNetwork->clearDestination();
 			}
 
@@ -1157,6 +1159,28 @@ void CYSFGateway::writeJSONRelinking(const std::string& protocol, const std::str
 	json["action"]    = "relinking";
 	json["reflector"] = reflector;
 	json["protocol"]  = protocol;
+
+	WriteJSON("link", json, true);
+}
+
+// "failed" was already declared in schema.json's action enum but never
+// actually published -- m_lostTimer's expiry handler in the main loop
+// already detects and logs this exact condition ("Link has failed, polls
+// lost", both YSF and FCS), covering a reflector that never answers a
+// link request at all (a mistyped/dead reflector ID -- the single most
+// likely real operator mistake) as well as one that goes silent
+// mid-session. It just never told MQTT, so the dashboard was left
+// showing a stale "linking" state indefinitely with no indication
+// anything was wrong.
+void CYSFGateway::writeJSONFailed(const std::string& reason, const std::string& reflector)
+{
+	nlohmann::json json;
+
+	json["timestamp"] = CUtils::createTimestamp();
+	json["action"]    = "failed";
+	json["reason"]    = reason;
+	if (!reflector.empty())
+		json["reflector"] = reflector;
 
 	WriteJSON("link", json, true);
 }

--- a/YSFGateway/YSFGateway.h
+++ b/YSFGateway/YSFGateway.h
@@ -80,6 +80,7 @@ private:
 	void writeJSONLinking(const std::string& reason, const std::string& protocol, const std::string& reflector);
 	void writeJSONUnlinked(const std::string& reason);
 	void writeJSONRelinking(const std::string& protocol, const std::string& reflector);
+	void writeJSONFailed(const std::string& reason, const std::string& reflector);
 
 	void writeCommand(const std::string& command);
 


### PR DESCRIPTION
Same PR as the other GW's - publish a *reason* why the link fails - covers YSFGateway and DGiDGateway.